### PR TITLE
Fix crash game script initialization

### DIFF
--- a/games.html
+++ b/games.html
@@ -332,7 +332,6 @@
             const historyBody = document.getElementById('recentGamesBody');
             const balanceEls = document.querySelectorAll('[data-balance]');
             const DEFAULT_BALANCE = 1000;
-main
 
             if (!betInput || !actionButton || !multiplierEl) {
                 return;
@@ -345,9 +344,6 @@ main
 
             const state = {
                 balance: DEFAULT_BALANCE,
-
-                balance: 0,
- main
                 running: false,
                 cashedOut: false,
                 intervalId: null,


### PR DESCRIPTION
## Summary
- remove stray tokens accidentally embedded in the Crash game script
- ensure the crash game state initializes correctly so betting and cash out logic can run

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c9c1117c7883209c18b93191b197cf