### PR TITLE
Handle admin verification without Firestore write access

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,616 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NEON CASINO | Admin Control Center</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js" defer></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script type="application/json" id="firebase-config">
+    {
+      "apiKey": "AIzaSyB_Dj7URsA_5N1okSuxCN5m2c7q7H9098o",
+      "authDomain": "casino-cd04e.firebaseapp.com",
+      "projectId": "casino-cd04e",
+      "storageBucket": "casino-cd04e.appspot.com",
+      "messagingSenderId": "237834419290"
+    }
+  </script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Poppins', 'sans-serif'],
+          },
+          colors: {
+            dark: '#0e0f13',
+            primary: '#00c2ff',
+            secondary: '#7c3aed',
+            accent: '#2bd975',
+          },
+          boxShadow: {
+            'neon-blue': '0 0 15px rgba(0, 194, 255, 0.5)',
+            'neon-purple': '0 0 15px rgba(124, 58, 237, 0.5)',
+            'neon-green': '0 0 15px rgba(43, 217, 117, 0.5)',
+            'glow-blue': '0 0 20px rgba(0, 194, 255, 0.65)',
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    body {
+      background: radial-gradient(circle at top left, rgba(0, 194, 255, 0.12), transparent 45%),
+        radial-gradient(circle at bottom right, rgba(124, 58, 237, 0.1), transparent 50%),
+        #070b15;
+      color: #f8fafc;
+    }
+    .glass-card {
+      background: rgba(255, 255, 255, 0.05);
+      backdrop-filter: blur(14px);
+      -webkit-backdrop-filter: blur(14px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    .gradient-btn {
+      background: linear-gradient(45deg, #00c2ff, #7c3aed);
+    }
+    .gradient-btn:hover {
+      box-shadow: 0 0 18px rgba(0, 194, 255, 0.6);
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      line-height: 1;
+      padding: 0.35rem 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .scroll-shadow {
+      position: relative;
+    }
+    .scroll-shadow::after {
+      content: '';
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 36px;
+      background: linear-gradient(90deg, rgba(7, 11, 21, 0), rgba(7, 11, 21, 1));
+    }
+  </style>
+</head>
+<body class="font-sans min-h-screen">
+  <nav class="fixed top-0 left-0 right-0 z-50 bg-dark/80 backdrop-blur-md border-b border-gray-800">
+    <div class="container mx-auto px-4 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-2">
+          <span class="text-2xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">NEON CASINO</span>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="index.html" class="text-white hover:text-primary transition">Home</a>
+          <a href="games.html" class="text-white hover:text-primary transition">Games</a>
+          <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+          <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+          <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+          <a href="admin.html" class="text-primary font-semibold transition">Admin</a>
+        </div>
+        <div class="hidden md:flex items-center space-x-4">
+          <div class="bg-gray-800 rounded-full px-4 py-1.5 flex items-center space-x-2">
+            <i data-feather="dollar-sign" class="w-4 h-4 text-accent"></i>
+            <span class="font-medium" data-balance data-default-balance="1000.00">1,000.00</span>
+          </div>
+          <div class="flex items-center gap-4" data-admin-auth-signed-out>
+            <a href="auth.html" class="gradient-btn rounded-full px-6 py-2 font-medium text-white hover:shadow-lg transition">
+              Sign In
+            </a>
+          </div>
+          <div class="hidden items-center gap-4" data-admin-auth-signed-in>
+            <div class="text-right">
+              <p class="text-[11px] uppercase tracking-[0.3em] text-gray-500">Administrator</p>
+              <p class="text-sm font-semibold text-white" data-admin-identity-name>—</p>
+              <p class="text-xs text-gray-400" data-admin-identity-email>—</p>
+            </div>
+            <button type="button" class="gradient-btn rounded-full px-6 py-2 font-medium text-white hover:shadow-lg transition" data-admin-signout>
+              Sign Out
+            </button>
+          </div>
+        </div>
+        <button type="button" class="md:hidden text-white focus:outline-none" data-mobile-toggle aria-expanded="false" aria-controls="mobile-menu">
+          <span class="sr-only">Toggle navigation</span>
+          <i data-feather="menu" class="w-6 h-6" data-icon-closed></i>
+          <i data-feather="x" class="w-6 h-6 hidden" data-icon-open></i>
+        </button>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden flex-col space-y-4 pt-4 border-t border-gray-800" data-mobile-menu>
+        <div class="flex flex-col space-y-3">
+          <a href="index.html" class="text-white hover:text-primary transition">Home</a>
+          <a href="games.html" class="text-white hover:text-primary transition">Games</a>
+          <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+          <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+          <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+          <a href="admin.html" class="text-primary font-semibold transition">Admin</a>
+        </div>
+        <div class="space-y-3 border-t border-gray-800 pt-4">
+          <div class="space-y-2">
+            <span class="text-xs uppercase tracking-wide text-gray-400">Wallet Balance</span>
+            <div class="bg-gray-800 rounded-full px-4 py-1.5 flex items-center space-x-2">
+              <i data-feather="dollar-sign" class="w-4 h-4 text-accent"></i>
+              <span class="font-medium" data-balance data-default-balance="1000.00">1,000.00</span>
+            </div>
+          </div>
+          <div class="space-y-3" data-admin-auth-signed-out>
+            <a href="auth.html" class="gradient-btn rounded-full px-6 py-2 font-medium text-white text-center hover:shadow-lg transition">
+              Sign In
+            </a>
+          </div>
+          <div class="hidden space-y-3" data-admin-auth-signed-in>
+            <div class="rounded-2xl border border-gray-800 px-4 py-3">
+              <p class="text-[11px] uppercase tracking-[0.3em] text-gray-500">Signed in as</p>
+              <p class="text-sm font-semibold text-white" data-admin-identity-name>—</p>
+              <p class="text-xs text-gray-400 mt-0.5" data-admin-identity-email>—</p>
+            </div>
+            <button type="button" class="gradient-btn rounded-full px-6 py-2 font-medium text-white text-center hover:shadow-lg transition" data-admin-signout>
+              Sign Out
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="pt-32 pb-16 px-4 relative overflow-hidden" data-admin-shell>
+    <div class="absolute inset-0 opacity-20" aria-hidden="true">
+      <div class="absolute top-1/5 left-1/4 w-72 h-72 rounded-full bg-primary blur-3xl"></div>
+      <div class="absolute bottom-1/5 right-1/5 w-72 h-72 rounded-full bg-secondary blur-3xl"></div>
+    </div>
+    <div class="container mx-auto relative z-10 space-y-12">
+      <section class="space-y-6" data-aos="fade-up">
+        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+          <div class="space-y-4 max-w-2xl">
+            <span class="inline-flex items-center rounded-full border border-primary/50 bg-primary/10 px-3 py-1 text-xs uppercase tracking-[0.3em] text-primary/80">Operations Console</span>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight">Admin Control Center</h1>
+            <p class="text-gray-300 text-base md:text-lg">Monitor player sentiment, orchestrate wallet balances, and resolve compliance events without leaving the Neon aesthetic. Every interaction is recorded in the audit trail for total transparency.</p>
+            <div class="flex flex-wrap items-center gap-3 text-xs text-gray-400">
+              <div class="flex items-center gap-2">
+                <span class="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0_4px_rgba(16,185,129,0.15)]"></span>
+                <span>Realtime ledger sync active</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="h-2 w-2 rounded-full bg-sky-400 shadow-[0_0_0_4px_rgba(14,165,233,0.15)]"></span>
+                <span>Risk engine connected</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="h-2 w-2 rounded-full bg-purple-400 shadow-[0_0_0_4px_rgba(139,92,246,0.15)]"></span>
+                <span>Last sync <span data-last-sync class="font-medium text-gray-300">—</span></span>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-col sm:flex-row items-stretch gap-3">
+            <button type="button" class="gradient-btn px-5 py-3 rounded-2xl text-sm font-semibold text-white shadow-neon-blue" data-add-user>
+              Create new user
+            </button>
+            <button type="button" class="px-5 py-3 rounded-2xl text-sm font-semibold text-primary border border-primary/40 bg-primary/5 hover:bg-primary/10 transition" data-export-users>
+              Export snapshot
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4" data-aos="fade-up" data-aos-delay="100">
+        <div class="glass-card rounded-2xl p-6 relative overflow-hidden">
+          <div class="absolute -top-10 -right-10 h-32 w-32 bg-primary/20 rounded-full blur-3xl"></div>
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs uppercase tracking-widest text-gray-400">Total users</p>
+              <p class="text-3xl font-bold text-white" data-summary="total-users">0</p>
+              <p class="text-xs text-gray-500 mt-1">Active now: <span class="text-primary font-semibold" data-summary="active-now">0</span></p>
+            </div>
+            <div class="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center border border-primary/40">
+              <i data-feather="users" class="w-5 h-5 text-primary"></i>
+            </div>
+          </div>
+        </div>
+        <div class="glass-card rounded-2xl p-6 relative overflow-hidden">
+          <div class="absolute -bottom-8 -left-10 h-32 w-32 bg-secondary/20 rounded-full blur-3xl"></div>
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs uppercase tracking-widest text-gray-400">Wallet float</p>
+              <p class="text-3xl font-bold text-white" data-summary="total-balance">$0.00</p>
+              <p class="text-xs text-gray-500 mt-1">Includes promotional credit</p>
+            </div>
+            <div class="h-12 w-12 rounded-full bg-secondary/10 flex items-center justify-center border border-secondary/40">
+              <i data-feather="database" class="w-5 h-5 text-secondary"></i>
+            </div>
+          </div>
+        </div>
+        <div class="glass-card rounded-2xl p-6 relative overflow-hidden">
+          <div class="absolute top-0 right-0 h-20 w-20 bg-accent/20 rounded-full blur-3xl"></div>
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs uppercase tracking-widest text-gray-400">New signups · 7d</p>
+              <p class="text-3xl font-bold text-white" data-summary="new-signups">0</p>
+              <p class="text-xs text-gray-500 mt-1">Auto welcome bonus sent</p>
+            </div>
+            <div class="h-12 w-12 rounded-full bg-accent/10 flex items-center justify-center border border-accent/30">
+              <i data-feather="user-plus" class="w-5 h-5 text-accent"></i>
+            </div>
+          </div>
+        </div>
+        <div class="glass-card rounded-2xl p-6 relative overflow-hidden">
+          <div class="absolute -bottom-12 -right-6 h-28 w-28 bg-blue-500/20 rounded-full blur-3xl"></div>
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs uppercase tracking-widest text-gray-400">Admin accounts</p>
+              <p class="text-3xl font-bold text-white" data-summary="admin-count">0</p>
+              <p class="text-xs text-gray-500 mt-1">Flagged accounts: <span data-summary="flagged" class="font-medium text-amber-200">0</span></p>
+            </div>
+            <div class="h-12 w-12 rounded-full bg-blue-500/10 flex items-center justify-center border border-blue-500/30">
+              <i data-feather="shield" class="w-5 h-5 text-blue-400"></i>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="grid gap-8 xl:grid-cols-[minmax(0,1.8fr)_minmax(0,1fr)] items-start">
+        <section class="glass-card rounded-3xl p-6 lg:p-8 space-y-6" data-aos="fade-up" data-aos-delay="150">
+          <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-semibold text-white">Player directory</h2>
+              <p class="text-sm text-gray-400 mt-1">Search, filter, and select any profile to reveal full wallet controls and compliance notes.</p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button type="button" class="px-4 py-2 rounded-xl text-xs font-semibold text-gray-300 border border-gray-700 hover:border-primary/40 hover:text-primary transition" data-refresh-users>Refresh data</button>
+              <button type="button" class="px-4 py-2 rounded-xl text-xs font-semibold text-gray-300 border border-gray-700 hover:border-secondary/40 hover:text-secondary transition" data-open-audit>Audit log</button>
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
+            <div class="relative flex-1">
+              <span class="absolute inset-y-0 left-3 flex items-center text-gray-500">
+                <i data-feather="search" class="w-4 h-4"></i>
+              </span>
+              <input type="search" placeholder="Search by name, email, or tag" class="w-full bg-black/30 border border-gray-800 rounded-xl pl-10 pr-4 py-2.5 text-sm text-white placeholder:text-gray-500 focus:border-primary/60 focus:ring-2 focus:ring-primary/20" data-user-search />
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full lg:w-auto">
+              <select class="bg-black/30 border border-gray-800 rounded-xl px-3 py-2 text-sm text-gray-200 focus:border-primary/50 focus:ring-2 focus:ring-primary/20" data-filter="status">
+                <option value="all">All statuses</option>
+                <option value="Active">Active</option>
+                <option value="Cooling Off">Cooling off</option>
+                <option value="Under Review">Under review</option>
+                <option value="Suspended">Suspended</option>
+              </select>
+              <select class="bg-black/30 border border-gray-800 rounded-xl px-3 py-2 text-sm text-gray-200 focus:border-primary/50 focus:ring-2 focus:ring-primary/20" data-filter="role">
+                <option value="all">All roles</option>
+                <option value="Player">Player</option>
+                <option value="VIP">VIP</option>
+                <option value="Moderator">Moderator</option>
+                <option value="Administrator">Administrator</option>
+              </select>
+              <select class="bg-black/30 border border-gray-800 rounded-xl px-3 py-2 text-sm text-gray-200 focus:border-primary/50 focus:ring-2 focus:ring-primary/20" data-filter="vip">
+                <option value="all">All VIP tiers</option>
+                <option value="Bronze">Bronze</option>
+                <option value="Silver">Silver</option>
+                <option value="Gold">Gold</option>
+                <option value="Platinum">Platinum</option>
+                <option value="Diamond">Diamond</option>
+                <option value="Obsidian">Obsidian</option>
+                <option value="Executive">Executive</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="overflow-x-auto rounded-2xl border border-gray-800/80">
+            <table class="min-w-full divide-y divide-gray-800/80 text-sm">
+              <thead class="bg-black/40 text-gray-400 uppercase text-xs tracking-wide">
+                <tr>
+                  <th scope="col" class="px-4 py-3 text-left">User</th>
+                  <th scope="col" class="px-4 py-3 text-left">Status</th>
+                  <th scope="col" class="px-4 py-3 text-left">Wallet</th>
+                  <th scope="col" class="px-4 py-3 text-left">VIP &amp; Role</th>
+                  <th scope="col" class="px-4 py-3 text-left">Last active</th>
+                  <th scope="col" class="px-4 py-3 text-left">Risk</th>
+                </tr>
+              </thead>
+              <tbody data-user-table class="bg-black/20 divide-y divide-gray-800/70"></tbody>
+            </table>
+          </div>
+
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-xs text-gray-500">
+            <span>Showing <span class="text-white font-semibold" data-table-count>0</span> of <span class="text-white font-semibold" data-table-total>0</span> profiles</span>
+            <span class="text-gray-500">Click a row to open full management controls</span>
+          </div>
+        </section>
+
+        <aside class="glass-card rounded-3xl p-6 lg:p-8 space-y-6" data-detail-panel data-aos="fade-up" data-aos-delay="200">
+          <div data-empty-view class="text-sm text-gray-400 space-y-3 hidden">
+            <p class="font-semibold text-white">Select a player</p>
+            <p>Choose a profile from the directory to unlock wallet controls, compliance flags, and communication utilities.</p>
+          </div>
+
+          <div data-selected-view class="space-y-7 hidden">
+            <div class="flex flex-col gap-4">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <p class="text-xs uppercase tracking-widest text-gray-500">Selected profile</p>
+                  <h2 class="text-2xl font-semibold text-white" data-detail-name>—</h2>
+                  <div class="flex flex-wrap gap-2 mt-3">
+                    <span class="badge border border-gray-700 text-gray-300" data-detail-role>—</span>
+                    <span class="badge border border-gray-700 text-gray-300" data-detail-status>—</span>
+                    <span class="badge border border-gray-700 text-gray-300" data-detail-vip>—</span>
+                  </div>
+                </div>
+                <div class="text-right space-y-3">
+                  <div>
+                    <p class="text-[11px] uppercase tracking-[0.25em] text-gray-500">User ID</p>
+                    <p class="font-mono text-sm text-gray-300" data-detail-id>—</p>
+                  </div>
+                  <button type="button" class="px-3 py-1.5 rounded-xl text-xs font-semibold border border-gray-700 text-gray-300 hover:text-primary hover:border-primary/40 transition" data-admin-action="impersonate" data-action-message="Impersonation session started in a sandbox window." data-action-tone="warning">
+                    Impersonate (demo)
+                  </button>
+                </div>
+              </div>
+              <div class="space-y-2 text-sm text-gray-400">
+                <a href="#" class="text-primary hover:text-primary/80 transition" data-detail-email>—</a>
+                <p><span class="text-gray-500">Location:</span> <span data-detail-location>—</span></p>
+                <p><span class="text-gray-500">Last active:</span> <span data-detail-last-active>—</span></p>
+              </div>
+              <div class="flex flex-wrap gap-2" data-detail-tags></div>
+              <div class="rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-200 hidden" data-detail-cooldown>
+                <p class="font-semibold">Cooling-off period in effect</p>
+                <p data-detail-cooldown-text class="mt-1 text-amber-100/80">—</p>
+              </div>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-3">
+              <div class="rounded-2xl border border-primary/30 bg-primary/10 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.3em] text-primary/70">Wallet balance</p>
+                <p class="text-xl font-semibold text-white mt-1" data-detail-balance>$0.00</p>
+              </div>
+              <div class="rounded-2xl border border-secondary/30 bg-secondary/10 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.3em] text-secondary/70">Lifetime deposits</p>
+                <p class="text-xl font-semibold text-white mt-1" data-detail-deposits>$0.00</p>
+              </div>
+              <div class="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.3em] text-emerald-200/80">Lifetime wagered</p>
+                <p class="text-xl font-semibold text-white mt-1" data-detail-wagered>$0.00</p>
+              </div>
+              <div class="rounded-2xl border border-blue-400/30 bg-blue-500/10 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.3em] text-blue-200/80">Lifetime payouts</p>
+                <p class="text-xl font-semibold text-white mt-1" data-detail-payouts>$0.00</p>
+              </div>
+            </div>
+
+            <form data-user-form class="space-y-7">
+              <div class="space-y-4">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-sm font-semibold text-white uppercase tracking-[0.3em]">General profile</h3>
+                  <button type="button" class="text-xs text-gray-400 hover:text-primary transition" data-reset-user>Reset</button>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Display name</span>
+                    <input name="userName" type="text" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" required />
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Email</span>
+                    <input name="userEmail" type="email" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" required />
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Role</span>
+                    <select name="userRole" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-200 focus:border-primary/60 focus:ring-2 focus:ring-primary/20">
+                      <option value="Player">Player</option>
+                      <option value="VIP">VIP</option>
+                      <option value="Moderator">Moderator</option>
+                      <option value="Administrator">Administrator</option>
+                    </select>
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Status</span>
+                    <select name="userStatus" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-200 focus:border-primary/60 focus:ring-2 focus:ring-primary/20">
+                      <option value="Active">Active</option>
+                      <option value="Cooling Off">Cooling off</option>
+                      <option value="Under Review">Under review</option>
+                      <option value="Suspended">Suspended</option>
+                    </select>
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">VIP tier</span>
+                    <select name="userVip" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-200 focus:border-primary/60 focus:ring-2 focus:ring-primary/20">
+                      <option value="Bronze">Bronze</option>
+                      <option value="Silver">Silver</option>
+                      <option value="Gold">Gold</option>
+                      <option value="Platinum">Platinum</option>
+                      <option value="Diamond">Diamond</option>
+                      <option value="Obsidian">Obsidian</option>
+                      <option value="Executive">Executive</option>
+                    </select>
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Risk level</span>
+                    <select name="userRisk" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-200 focus:border-primary/60 focus:ring-2 focus:ring-primary/20">
+                      <option value="Low">Low</option>
+                      <option value="Medium">Medium</option>
+                      <option value="Elevated">Elevated</option>
+                      <option value="Critical">Critical</option>
+                    </select>
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Location</span>
+                    <input name="userLocation" type="text" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" placeholder="City, Country" />
+                  </label>
+                </div>
+              </div>
+
+              <div class="space-y-4">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-sm font-semibold text-white uppercase tracking-[0.3em]">Wallet controls</h3>
+                  <button type="button" class="text-xs text-gray-400 hover:text-primary transition" data-balance-reset>Reset balance</button>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Current balance (USD)</span>
+                    <input name="userBalance" type="number" step="0.01" min="0" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" data-balance-input />
+                  </label>
+                  <div class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Quick adjustments</span>
+                    <div class="flex flex-wrap gap-2">
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-primary/40 text-primary text-xs font-semibold hover:bg-primary/10 transition" data-balance-adjust="25">+ $25</button>
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-primary/40 text-primary text-xs font-semibold hover:bg-primary/10 transition" data-balance-adjust="100">+ $100</button>
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-primary/40 text-primary text-xs font-semibold hover:bg-primary/10 transition" data-balance-adjust="500">+ $500</button>
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-rose-400/40 text-rose-200 text-xs font-semibold hover:bg-rose-500/10 transition" data-balance-adjust="-25">- $25</button>
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-rose-400/40 text-rose-200 text-xs font-semibold hover:bg-rose-500/10 transition" data-balance-adjust="-100">- $100</button>
+                      <button type="button" class="px-3 py-1.5 rounded-lg border border-gray-700 text-gray-300 text-xs font-semibold hover:bg-gray-800/60 transition" data-balance-action="zero">Set to $0</button>
+                    </div>
+                  </div>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Lifetime deposits</span>
+                    <input name="userDeposits" type="number" step="0.01" min="0" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" />
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Lifetime wagered</span>
+                    <input name="userWagered" type="number" step="0.01" min="0" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" />
+                  </label>
+                  <label class="space-y-2 text-sm text-gray-300">
+                    <span class="text-xs uppercase tracking-widest text-gray-500">Lifetime payouts</span>
+                    <input name="userPayouts" type="number" step="0.01" min="0" class="w-full bg-black/30 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" />
+                  </label>
+                </div>
+              </div>
+
+              <div class="space-y-3">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-[0.3em]">Security &amp; compliance</h3>
+                <label class="flex items-center gap-3 text-sm text-gray-300">
+                  <input type="checkbox" name="userTwoFactor" class="h-4 w-4 rounded border-gray-700 bg-black/40 text-primary focus:ring-primary/40" />
+                  <span>Two-factor authentication enabled</span>
+                </label>
+                <label class="flex items-center gap-3 text-sm text-gray-300">
+                  <input type="checkbox" name="userEmailVerified" class="h-4 w-4 rounded border-gray-700 bg-black/40 text-primary focus:ring-primary/40" />
+                  <span>Email verified</span>
+                </label>
+                <label class="flex items-center gap-3 text-sm text-gray-300">
+                  <input type="checkbox" name="userPayoutHold" class="h-4 w-4 rounded border-gray-700 bg-black/40 text-primary focus:ring-primary/40" />
+                  <span>Withdrawal hold active</span>
+                </label>
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <button type="button" class="px-3 py-2 rounded-xl text-xs font-semibold border border-gray-700 text-gray-300 hover:text-accent hover:border-accent/50 transition" data-admin-action="send-reset" data-action-message="Password reset email queued for delivery.">Send reset email</button>
+                  <button type="button" class="px-3 py-2 rounded-xl text-xs font-semibold border border-gray-700 text-gray-300 hover:text-secondary hover:border-secondary/50 transition" data-admin-action="send-summary" data-action-message="Account summary emailed to player." data-action-tone="success">Send account summary</button>
+                  <button type="button" class="px-3 py-2 rounded-xl text-xs font-semibold border border-rose-500/40 text-rose-200 hover:bg-rose-500/10 transition" data-admin-action="suspend" data-action-message="Account suspended. Player notified automatically." data-action-tone="danger">Suspend account</button>
+                  <button type="button" class="px-3 py-2 rounded-xl text-xs font-semibold border border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/10 transition" data-admin-action="schedule-call" data-action-message="Responsible gaming check-in scheduled.">Schedule wellbeing call</button>
+                </div>
+              </div>
+
+              <div class="space-y-3">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-[0.3em]">Internal notes</h3>
+                <textarea name="userNotes" rows="4" class="w-full bg-black/30 border border-gray-800 rounded-2xl px-4 py-3 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" placeholder="Add retention plans, compliance reminders, or player preferences."></textarea>
+                <div class="flex items-center justify-end gap-3">
+                  <button type="button" class="px-4 py-2 rounded-xl text-xs font-semibold border border-gray-700 text-gray-300 hover:text-primary hover:border-primary/40 transition" data-reset-user>Revert changes</button>
+                  <button type="submit" class="gradient-btn px-4 py-2 rounded-xl text-xs font-semibold text-white shadow-neon-blue">Save changes</button>
+                </div>
+              </div>
+            </form>
+
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-[0.3em]">Recent activity</h3>
+                <button type="button" class="text-xs text-gray-400 hover:text-primary transition" data-admin-action="refresh-activity" data-action-message="Activity feed synced." data-action-tone="success">Refresh</button>
+              </div>
+              <ul class="space-y-3 max-h-60 overflow-y-auto pr-1" data-activity-list></ul>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <section class="glass-card rounded-3xl p-6 lg:p-8 space-y-6" data-aos="fade-up" data-aos-delay="250">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h2 class="text-2xl font-semibold text-white">Audit timeline</h2>
+            <p class="text-sm text-gray-400 mt-1">Every balance adjustment, verification event, and status change is captured for accountability.</p>
+          </div>
+          <button type="button" class="px-4 py-2 rounded-xl text-xs font-semibold border border-gray-700 text-gray-300 hover:text-primary hover:border-primary/40 transition" data-refresh-audit>Refresh timeline</button>
+        </div>
+        <div class="space-y-6" data-audit-list></div>
+      </section>
+    </div>
+  </main>
+
+  <div class="hidden fixed bottom-6 right-6 z-50 max-w-xs px-5 py-4 rounded-2xl border text-sm shadow-lg backdrop-blur" data-toast>
+    <div class="flex items-center justify-between gap-4">
+      <p data-toast-message class="font-medium">Action completed.</p>
+      <button type="button" class="text-xs uppercase tracking-widest text-gray-400 hover:text-white transition" data-toast-close>&times;</button>
+    </div>
+  </div>
+
+  
+  <div class="hidden fixed inset-0 z-50" data-admin-gate>
+    <div class="absolute inset-0 bg-black/70 backdrop-blur-lg"></div>
+    <div class="relative z-10 flex h-full w-full items-center justify-center px-4">
+      <div class="glass-card w-full max-w-md rounded-3xl border border-gray-800/80 bg-black/60 p-8 text-center shadow-[0_20px_60px_rgba(8,15,35,0.8)] hidden" data-gate-screen="loading">
+        <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <svg class="h-6 w-6 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+          </svg>
+        </div>
+        <h2 class="text-xl font-semibold text-white">Preparing admin console</h2>
+        <p class="mt-2 text-sm text-gray-400">Connecting to Firebase and verifying your access…</p>
+      </div>
+
+      <div class="glass-card w-full max-w-md space-y-6 rounded-3xl border border-gray-800/80 bg-black/60 p-8 shadow-[0_20px_60px_rgba(8,15,35,0.8)] hidden text-left" data-gate-screen="login">
+        <div class="space-y-2">
+          <span class="inline-flex items-center rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary/70">Admin access</span>
+          <h2 class="text-2xl font-semibold text-white">Sign in to continue</h2>
+          <p class="text-sm text-gray-400">Use your administrator credentials to unlock real-time user management tools.</p>
+        </div>
+        <form class="space-y-4" data-admin-login-form>
+          <div class="space-y-2">
+            <label class="text-xs uppercase tracking-[0.3em] text-gray-500">Email</label>
+            <input type="email" name="email" required class="w-full rounded-xl border border-gray-800 bg-black/40 px-4 py-3 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" placeholder="admin@example.com" data-admin-login-email />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs uppercase tracking-[0.3em] text-gray-500">Password</label>
+            <input type="password" name="password" required class="w-full rounded-xl border border-gray-800 bg-black/40 px-4 py-3 text-sm text-white focus:border-primary/60 focus:ring-2 focus:ring-primary/20" placeholder="••••••••" data-admin-login-password />
+          </div>
+          <p class="hidden rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-sm text-rose-200" data-admin-login-error></p>
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <button type="button" class="text-xs font-semibold uppercase tracking-[0.3em] text-gray-400 hover:text-primary transition" data-admin-login-reset>Send reset email</button>
+            <button type="submit" class="gradient-btn w-full sm:w-auto rounded-xl px-6 py-3 text-sm font-semibold text-white shadow-neon-blue" data-admin-login-submit>
+              Sign In
+            </button>
+          </div>
+        </form>
+        <p class="text-xs text-gray-500">Only approved administrators can access player balances, compliance flags, and audit logs.</p>
+      </div>
+
+      <div class="glass-card w-full max-w-md space-y-4 rounded-3xl border border-amber-500/30 bg-black/60 p-8 text-center shadow-[0_20px_60px_rgba(8,15,35,0.8)] hidden" data-gate-screen="unauthorized">
+        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-amber-500/10 text-amber-300">
+          <i data-feather="shield-off" class="h-6 w-6"></i>
+        </div>
+        <h2 class="text-2xl font-semibold text-white">Access requires elevation</h2>
+        <p class="text-sm text-gray-400" data-admin-unauthorized-message></p>
+        <button type="button" class="gradient-btn rounded-xl px-6 py-3 text-sm font-semibold text-white shadow-neon-blue" data-admin-signout>
+          Switch account
+        </button>
+      </div>
+
+      <div class="glass-card w-full max-w-md space-y-4 rounded-3xl border border-rose-500/40 bg-black/60 p-8 text-center shadow-[0_20px_60px_rgba(8,15,35,0.8)] hidden" data-gate-screen="error">
+        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-rose-500/10 text-rose-300">
+          <i data-feather="alert-triangle" class="h-6 w-6"></i>
+        </div>
+        <h2 class="text-2xl font-semibold text-white">Unable to load admin tools</h2>
+        <p class="text-sm text-gray-400" data-admin-error-message></p>
+        <button type="button" class="gradient-btn rounded-xl px-6 py-3 text-sm font-semibold text-white shadow-neon-blue" data-admin-retry>Retry</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,1942 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut,
+  sendPasswordResetEmail,
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+  addDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  limit,
+  serverTimestamp,
+  runTransaction,
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+
+const ADMIN_EMAIL = 'jhuxf12@outlook.com';
+const BALANCE_STORAGE_KEY = 'neonCasinoBalance';
+
+const toneStyles = {
+  emerald: 'bg-emerald-500/10 border border-emerald-500/40 text-emerald-200',
+  sky: 'bg-sky-500/10 border border-sky-500/40 text-sky-200',
+  amber: 'bg-amber-500/10 border border-amber-500/40 text-amber-200',
+  rose: 'bg-rose-500/10 border border-rose-500/40 text-rose-200',
+  violet: 'bg-violet-500/10 border border-violet-500/40 text-violet-200',
+};
+
+const vipStyles = {
+  Bronze: 'border border-amber-500/30 text-amber-200 bg-amber-500/10',
+  Silver: 'border border-slate-300/30 text-slate-100 bg-slate-300/10',
+  Gold: 'border border-yellow-500/30 text-yellow-200 bg-yellow-500/10',
+  Platinum: 'border border-blue-400/30 text-blue-100 bg-blue-400/10',
+  Diamond: 'border border-cyan-400/30 text-cyan-100 bg-cyan-400/10',
+  Obsidian: 'border border-purple-500/30 text-purple-200 bg-purple-500/10',
+  Executive: 'border border-emerald-500/30 text-emerald-200 bg-emerald-500/10',
+};
+
+const statusStyles = {
+  Active: 'border border-emerald-400/40 text-emerald-200 bg-emerald-500/10',
+  'Cooling Off': 'border border-amber-400/40 text-amber-200 bg-amber-500/10',
+  'Under Review': 'border border-sky-400/40 text-sky-200 bg-sky-500/10',
+  Suspended: 'border border-rose-500/40 text-rose-200 bg-rose-500/10',
+};
+
+const statusIndicators = {
+  Active: 'bg-emerald-400',
+  'Cooling Off': 'bg-amber-400',
+  'Under Review': 'bg-sky-400',
+  Suspended: 'bg-rose-500',
+};
+
+const riskStyles = {
+  Low: 'border border-emerald-400/40 text-emerald-200 bg-emerald-500/10',
+  Medium: 'border border-amber-400/40 text-amber-200 bg-amber-500/10',
+  Elevated: 'border border-orange-400/40 text-orange-200 bg-orange-500/10',
+  Critical: 'border border-rose-500/40 text-rose-200 bg-rose-500/10',
+};
+
+const roleStyles = {
+  Player: 'border border-gray-700 text-gray-300 bg-gray-800/40',
+  VIP: 'border border-purple-400/40 text-purple-200 bg-purple-500/10',
+  Moderator: 'border border-blue-400/40 text-blue-200 bg-blue-500/10',
+  Administrator: 'border border-primary/40 text-primary bg-primary/10',
+};
+
+const state = {
+  authUser: null,
+  adminProfile: null,
+  auth: null,
+  db: null,
+  users: [],
+  visibleUsers: [],
+  activeUserId: null,
+  auditEntries: [],
+  userActivity: [],
+  filters: {
+    search: '',
+    status: 'all',
+    role: 'all',
+    vip: 'all',
+  },
+  formInitialData: null,
+  formDirty: false,
+  usersUnsub: null,
+  auditUnsub: null,
+  activityUnsub: null,
+  lastSync: null,
+  usersFallback: false,
+};
+
+const elements = {
+  shell: document.querySelector('[data-admin-shell]'),
+  tableBody: document.querySelector('[data-user-table]'),
+  tableCount: document.querySelector('[data-table-count]'),
+  tableTotal: document.querySelector('[data-table-total]'),
+  searchInput: document.querySelector('[data-user-search]'),
+  filters: {
+    status: document.querySelector('[data-filter="status"]'),
+    role: document.querySelector('[data-filter="role"]'),
+    vip: document.querySelector('[data-filter="vip"]'),
+  },
+  summary: {
+    totalUsers: document.querySelector('[data-summary="total-users"]'),
+    totalBalance: document.querySelector('[data-summary="total-balance"]'),
+    newSignups: document.querySelector('[data-summary="new-signups"]'),
+    adminCount: document.querySelector('[data-summary="admin-count"]'),
+    activeNow: document.querySelector('[data-summary="active-now"]'),
+    flagged: document.querySelector('[data-summary="flagged"]'),
+  },
+  lastSync: document.querySelector('[data-last-sync]'),
+  detailPanel: document.querySelector('[data-detail-panel]'),
+  activityList: document.querySelector('[data-activity-list]'),
+  auditList: document.querySelector('[data-audit-list]'),
+  selectedView: document.querySelector('[data-selected-view]'),
+  emptyView: document.querySelector('[data-empty-view]'),
+  userForm: document.querySelector('[data-user-form]'),
+  balanceInput: document.querySelector('[data-balance-input]'),
+  toast: document.querySelector('[data-toast]'),
+  toastMessage: document.querySelector('[data-toast-message]'),
+  toastClose: document.querySelector('[data-toast-close]'),
+  auditButton: document.querySelector('[data-open-audit]'),
+  refreshUsers: document.querySelector('[data-refresh-users]'),
+  refreshAudit: document.querySelector('[data-refresh-audit]'),
+  exportUsers: document.querySelector('[data-export-users]'),
+  lastSyncTarget: document.querySelector('[data-last-sync]'),
+};
+
+elements.detail = elements.detailPanel
+  ? {
+      name: elements.detailPanel.querySelector('[data-detail-name]'),
+      email: elements.detailPanel.querySelector('[data-detail-email]'),
+      id: elements.detailPanel.querySelector('[data-detail-id]'),
+      role: elements.detailPanel.querySelector('[data-detail-role]'),
+      status: elements.detailPanel.querySelector('[data-detail-status]'),
+      vip: elements.detailPanel.querySelector('[data-detail-vip]'),
+      balance: elements.detailPanel.querySelector('[data-detail-balance]'),
+      deposits: elements.detailPanel.querySelector('[data-detail-deposits]'),
+      wagered: elements.detailPanel.querySelector('[data-detail-wagered]'),
+      payouts: elements.detailPanel.querySelector('[data-detail-payouts]'),
+      lastActive: elements.detailPanel.querySelector('[data-detail-last-active]'),
+      location: elements.detailPanel.querySelector('[data-detail-location]'),
+      tags: elements.detailPanel.querySelector('[data-detail-tags]'),
+      cooldown: elements.detailPanel.querySelector('[data-detail-cooldown]'),
+      cooldownText: elements.detailPanel.querySelector('[data-detail-cooldown-text]'),
+    }
+  : {};
+
+elements.nav = {
+  signedIn: document.querySelectorAll('[data-admin-auth-signed-in]'),
+  signedOut: document.querySelectorAll('[data-admin-auth-signed-out]'),
+  identityName: document.querySelectorAll('[data-admin-identity-name]'),
+  identityEmail: document.querySelectorAll('[data-admin-identity-email]'),
+  signOut: document.querySelectorAll('[data-admin-signout]'),
+};
+
+const gate = createGateController();
+const toast = createToast();
+
+initNavigation();
+initAOSAndFeather();
+
+const firebaseConfig = readFirebaseConfig();
+
+if (!firebaseConfig) {
+  gate.showError('Firebase configuration is missing. Update the <script id="firebase-config"> block with your web app credentials.');
+} else {
+  try {
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    const db = getFirestore(app);
+    initAdminApp({ auth, db });
+  } catch (error) {
+    console.error('Failed to initialize Firebase', error);
+    gate.showError('We were unable to connect to Firebase. Verify your configuration and reload the page.');
+  }
+}
+
+function initAdminApp({ auth, db }) {
+  state.auth = auth;
+  state.db = db;
+  if (elements.shell) {
+    elements.shell.hidden = true;
+  }
+
+  setupLoginFlow(auth);
+  setupNavSignOut(auth);
+  setupFilterControls();
+  setupQuickActions(auth, db);
+
+  gate.showLoading();
+
+  onAuthStateChanged(auth, async user => {
+    cleanupListeners();
+    if (!user) {
+      state.authUser = null;
+      state.adminProfile = null;
+      setNavSignedOut();
+      if (elements.shell) {
+        elements.shell.hidden = true;
+      }
+      gate.showLogin();
+      return;
+    }
+
+    gate.showLoading();
+    try {
+      const profile = await ensureAdminProfile(db, user);
+      state.authUser = user;
+      state.adminProfile = profile;
+
+      if (!profile.isAdmin) {
+        setNavSignedOut();
+        if (elements.shell) {
+          elements.shell.hidden = true;
+        }
+        gate.showUnauthorized(`The account ${profile.email || user.email || 'unknown'} is not authorized for administrator access.`);
+        return;
+      }
+
+      setNavSignedIn(profile);
+      gate.close();
+      if (elements.shell) {
+        elements.shell.hidden = false;
+      }
+
+      let userDirectoryError = null;
+      let auditError = null;
+      try {
+        await fetchUsersOnce(db);
+      } catch (error) {
+        userDirectoryError = error;
+        console.error('Initial user directory load failed', error);
+        toast.show('Unable to load existing players. Realtime updates will keep trying.', 'danger');
+      }
+      try {
+        await fetchAuditOnce(db);
+      } catch (error) {
+        auditError = error;
+        console.error('Initial audit log load failed', error);
+        toast.show('Audit timeline could not be loaded. Realtime updates will retry automatically.', 'danger');
+      }
+
+      subscribeToUsers(db);
+      subscribeToAudit(db);
+
+      if (!userDirectoryError && !auditError && state.users.length) {
+        if (state.usersFallback) {
+          toast.show('Admin data loaded with basic ordering. Create an index to unlock live sorting.', 'warning');
+        } else {
+          toast.show('Admin data synchronized with Firebase.', 'success');
+        }
+      }
+    } catch (error) {
+      console.error('Failed to prepare admin profile', error);
+      gate.showError('We could not verify your administrator permissions. Try reloading the page.');
+    }
+  });
+}
+
+function setupLoginFlow(auth) {
+  const form = gate.loginForm;
+  const emailInput = gate.loginEmail;
+  const passwordInput = gate.loginPassword;
+  const submitButton = gate.loginSubmit;
+  const resetButton = gate.resetButton;
+
+  function setFormLoading(isLoading) {
+    if (!submitButton) {
+      return;
+    }
+    submitButton.disabled = isLoading;
+    submitButton.classList.toggle('opacity-60', isLoading);
+    submitButton.textContent = isLoading ? 'Signing In…' : 'Sign In';
+  }
+
+  function clearError() {
+    if (gate.loginError) {
+      gate.loginError.classList.add('hidden');
+      gate.loginError.textContent = '';
+    }
+  }
+
+  function showError(message) {
+    if (gate.loginError) {
+      gate.loginError.textContent = message;
+      gate.loginError.classList.remove('hidden');
+    }
+  }
+
+  if (form) {
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      clearError();
+      const email = (emailInput?.value || '').trim();
+      const password = passwordInput?.value || '';
+      if (!email || !password) {
+        showError('Enter your email and password to continue.');
+        return;
+      }
+      setFormLoading(true);
+      try {
+        await signInWithEmailAndPassword(auth, email, password);
+      } catch (error) {
+        console.error('Login failed', error);
+        showError(getFriendlyErrorMessage(error));
+      } finally {
+        setFormLoading(false);
+      }
+    });
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', async () => {
+      clearError();
+      const email = (emailInput?.value || '').trim();
+      if (!email) {
+        showError('Enter the email address to send the reset link.');
+        return;
+      }
+      resetButton.disabled = true;
+      try {
+        await sendPasswordResetEmail(auth, email);
+        toast.show(`Password reset instructions sent to ${email}.`, 'info');
+      } catch (error) {
+        console.error('Reset email failed', error);
+        showError(getFriendlyErrorMessage(error));
+      } finally {
+        resetButton.disabled = false;
+      }
+    });
+  }
+
+  if (gate.retryButton) {
+    gate.retryButton.addEventListener('click', () => {
+      gate.showLogin();
+    });
+  }
+}
+
+function setupNavSignOut(auth) {
+  elements.nav.signOut.forEach(button => {
+    button.addEventListener('click', async () => {
+      try {
+        await signOut(auth);
+        toast.show('Signed out of the admin console.', 'info');
+      } catch (error) {
+        console.error('Sign out failed', error);
+        toast.show('Unable to sign out. Try again.', 'danger');
+      }
+    });
+  });
+}
+
+function setupFilterControls() {
+  if (elements.searchInput) {
+    elements.searchInput.addEventListener('input', event => {
+      state.filters.search = (event.target.value || '').trim().toLowerCase();
+      updateVisibleUsers();
+    });
+  }
+
+  Object.entries(elements.filters).forEach(([key, element]) => {
+    if (!element) {
+      return;
+    }
+    element.addEventListener('change', event => {
+      state.filters[key] = event.target.value;
+      updateVisibleUsers();
+    });
+  });
+}
+
+function setupQuickActions(auth, db) {
+  if (elements.toastClose) {
+    elements.toastClose.addEventListener('click', () => toast.hide());
+  }
+
+  document.querySelectorAll('[data-balance-adjust]').forEach(button => {
+    button.addEventListener('click', () => {
+      if (!elements.balanceInput) {
+        return;
+      }
+      const delta = Number.parseFloat(button.getAttribute('data-balance-adjust') || '0');
+      const current = Number.parseFloat(elements.balanceInput.value || '0');
+      const nextValue = Math.max(0, Number.isFinite(current) ? current + delta : delta);
+      elements.balanceInput.value = nextValue.toFixed(2);
+      state.formDirty = true;
+    });
+  });
+
+  document.querySelectorAll('[data-balance-reset]').forEach(button => {
+    button.addEventListener('click', () => {
+      resetFormToInitial();
+      toast.show('Values reset to the latest saved state.', 'info');
+    });
+  });
+
+  document.querySelectorAll('[data-balance-action="zero"]').forEach(button => {
+    button.addEventListener('click', () => {
+      if (!elements.balanceInput) {
+        return;
+      }
+      elements.balanceInput.value = '0.00';
+      state.formDirty = true;
+    });
+  });
+
+  document.querySelectorAll('[data-reset-user]').forEach(button => {
+    button.addEventListener('click', () => {
+      resetFormToInitial();
+      toast.show('Pending changes discarded.', 'info');
+    });
+  });
+
+  if (elements.auditButton) {
+    elements.auditButton.addEventListener('click', () => {
+      elements.auditList?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      toast.show('Navigated to the audit timeline.', 'info');
+    });
+  }
+
+  if (elements.refreshUsers) {
+    elements.refreshUsers.addEventListener('click', async () => {
+      try {
+        await fetchUsersOnce(state.db);
+        if (state.usersFallback) {
+          toast.show('User directory refreshed. Ordering is limited until an index is created.', 'warning');
+        } else {
+          toast.show('User directory refreshed.', 'success');
+        }
+      } catch (error) {
+        console.error('Manual user refresh failed', error);
+        toast.show('Unable to refresh users. Check your connection.', 'danger');
+      }
+    });
+  }
+
+  if (elements.refreshAudit) {
+    elements.refreshAudit.addEventListener('click', async () => {
+      try {
+        await fetchAuditOnce(state.db);
+        toast.show('Audit log updated.', 'success');
+      } catch (error) {
+        console.error('Manual audit refresh failed', error);
+        toast.show('Unable to refresh audit timeline.', 'danger');
+      }
+    });
+  }
+
+  if (elements.exportUsers) {
+    elements.exportUsers.addEventListener('click', () => {
+      exportUsersToCsv();
+    });
+  }
+
+  const activityRefresh = document.querySelector('[data-admin-action="refresh-activity"]');
+  if (activityRefresh) {
+    activityRefresh.addEventListener('click', () => {
+      if (!state.activeUserId) {
+        toast.show('Select a player first.', 'warning');
+        return;
+      }
+      subscribeToActivity(state.activeUserId, true);
+      toast.show('Activity feed refreshed.', 'success');
+    });
+  }
+
+  if (elements.userForm) {
+    elements.userForm.addEventListener('input', () => {
+      state.formDirty = true;
+    });
+    elements.userForm.addEventListener('change', () => {
+      state.formDirty = true;
+    });
+    elements.userForm.addEventListener('submit', event => handleUserFormSubmit(event, auth, db));
+  }
+
+  document.querySelectorAll('[data-admin-action]').forEach(button => {
+    button.addEventListener('click', async () => {
+      if (!state.activeUserId) {
+        toast.show('Select a player first.', 'warning');
+        return;
+      }
+      const action = button.getAttribute('data-admin-action');
+      const user = state.users.find(item => item.id === state.activeUserId);
+      if (!user) {
+        toast.show('Player data unavailable. Wait for synchronization.', 'warning');
+        return;
+      }
+      try {
+        const dbInstance = state.db || getFirestore();
+        switch (action) {
+          case 'impersonate':
+            await logAuditEvent(dbInstance, {
+              userId: user.id,
+              userName: user.name,
+              userEmail: user.email,
+              action: 'Sandbox impersonation started',
+              description: 'Opened a secure sandbox session for diagnostics.',
+              tone: 'sky',
+            });
+            toast.show('Sandbox impersonation session opened (demo).', 'info');
+            break;
+          case 'send-reset':
+            await sendPasswordResetEmail(auth, user.email);
+            await logAuditEvent(dbInstance, {
+              userId: user.id,
+              userName: user.name,
+              userEmail: user.email,
+              action: 'Password reset email sent',
+              description: 'Administrator dispatched a password reset email.',
+              tone: 'emerald',
+            });
+            toast.show('Password reset email sent.', 'success');
+            break;
+          case 'send-summary':
+            await logAuditEvent(dbInstance, {
+              userId: user.id,
+              userName: user.name,
+              userEmail: user.email,
+              action: 'Account summary emailed',
+              description: 'Account snapshot queued for delivery to the player.',
+              tone: 'violet',
+            });
+            toast.show('Account summary queued for delivery.', 'success');
+            break;
+          case 'suspend':
+            await updateDoc(doc(dbInstance, 'users', user.id), {
+              status: 'Suspended',
+              payoutHold: true,
+              updatedAt: serverTimestamp(),
+            });
+            await logAuditEvent(dbInstance, {
+              userId: user.id,
+              userName: user.name,
+              userEmail: user.email,
+              action: 'Account suspended',
+              description: 'Administrator suspended the account and enabled withdrawal hold.',
+              tone: 'rose',
+            });
+            toast.show('Account suspended and withdrawal hold enabled.', 'warning');
+            break;
+          case 'schedule-call':
+            await logAuditEvent(dbInstance, {
+              userId: user.id,
+              userName: user.name,
+              userEmail: user.email,
+              action: 'Wellbeing call scheduled',
+              description: 'Responsible gaming outreach scheduled for the player.',
+              tone: 'amber',
+            });
+            toast.show('Wellbeing call scheduled.', 'success');
+            break;
+          default:
+            break;
+        }
+      } catch (error) {
+        console.error('Action failed', error);
+        toast.show('Unable to complete the requested action.', 'danger');
+      }
+    });
+  });
+}
+
+function cleanupListeners() {
+  if (typeof state.usersUnsub === 'function') {
+    state.usersUnsub();
+    state.usersUnsub = null;
+  }
+  if (typeof state.auditUnsub === 'function') {
+    state.auditUnsub();
+    state.auditUnsub = null;
+  }
+  if (typeof state.activityUnsub === 'function') {
+    state.activityUnsub();
+    state.activityUnsub = null;
+  }
+  state.users = [];
+  state.visibleUsers = [];
+  state.activeUserId = null;
+  state.auditEntries = [];
+  state.userActivity = [];
+  state.usersFallback = false;
+  state.lastSync = null;
+  updateVisibleUsers();
+  renderAudit();
+  renderActivity();
+  updateLastSync();
+}
+
+async function ensureAdminProfile(db, user) {
+  const userRef = doc(db, 'users', user.uid);
+  let snapshot = null;
+  try {
+    snapshot = await getDoc(userRef);
+  } catch (error) {
+    console.warn('Unable to read administrator profile. Continuing with fallbacks.', error);
+  }
+  const baseDisplayName = user.displayName || (user.email ? user.email.split('@')[0] : 'Administrator');
+  const isRequestedAdmin = (user.email || '').toLowerCase() === ADMIN_EMAIL.toLowerCase();
+  const defaults = {
+    displayName: baseDisplayName || 'Administrator',
+    email: user.email ?? null,
+    balance: 0,
+    role: isRequestedAdmin ? 'Administrator' : 'Player',
+    status: 'Active',
+    vipTier: isRequestedAdmin ? 'Executive' : 'Bronze',
+    riskLevel: 'Low',
+    lifetimeDeposits: 0,
+    lifetimeWagered: 0,
+    lifetimePayouts: 0,
+    segments: isRequestedAdmin ? ['Admin'] : [],
+    notes: '',
+    twoFactor: false,
+    emailVerified: user.emailVerified ?? false,
+    payoutHold: false,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    lastLoginAt: serverTimestamp(),
+    isAdmin: isRequestedAdmin,
+  };
+
+  let data = snapshot?.exists() ? snapshot.data() || {} : {};
+  const updates = {};
+
+  const safeMerge = payload => {
+    if (!payload || typeof payload !== 'object') {
+      return;
+    }
+    data = { ...data, ...payload };
+  };
+
+  const safeUpdate = async (payload, context) => {
+    if (!payload || !Object.keys(payload).length) {
+      return;
+    }
+    try {
+      await updateDoc(userRef, payload);
+      safeMerge(payload);
+    } catch (error) {
+      console.warn(context || 'Unable to sync admin profile updates', error);
+    }
+  };
+
+  if (!snapshot?.exists()) {
+    try {
+      await setDoc(userRef, defaults);
+      data = { ...defaults };
+    } catch (error) {
+      console.warn('Unable to create administrator profile. Using local defaults.', error);
+      data = { ...defaults, createdAt: null, updatedAt: null };
+    }
+  } else {
+    if (!data.displayName && defaults.displayName) {
+      updates.displayName = defaults.displayName;
+    }
+    if (!data.email && user.email) {
+      updates.email = user.email;
+    }
+    if (typeof data.balance !== 'number') {
+      updates.balance = 0;
+    }
+    if (!data.status) {
+      updates.status = 'Active';
+    }
+    if (!data.role) {
+      updates.role = 'Player';
+    }
+    if (!data.vipTier) {
+      updates.vipTier = 'Bronze';
+    }
+    if (!data.riskLevel) {
+      updates.riskLevel = 'Low';
+    }
+    if (!Array.isArray(data.segments)) {
+      updates.segments = defaults.segments;
+    }
+    if (typeof data.emailVerified !== 'boolean') {
+      updates.emailVerified = user.emailVerified ?? false;
+    }
+    if (isRequestedAdmin) {
+      if (data.isAdmin !== true) {
+        updates.isAdmin = true;
+      }
+      const existingRole = typeof data.role === 'string' ? data.role.toLowerCase() : '';
+      if (existingRole !== 'administrator') {
+        updates.role = 'Administrator';
+      }
+      if (data.vipTier !== 'Executive') {
+        updates.vipTier = 'Executive';
+      }
+      const segmentSource = Object.prototype.hasOwnProperty.call(updates, 'segments')
+        ? updates.segments
+        : data.segments;
+      const currentSegments = Array.isArray(segmentSource) ? segmentSource : [];
+      if (!currentSegments.includes('Admin')) {
+        updates.segments = Array.from(new Set([...currentSegments, 'Admin']));
+      }
+    }
+    if (Object.keys(updates).length) {
+      updates.updatedAt = serverTimestamp();
+      await safeUpdate(updates, 'Unable to sync administrator defaults');
+    }
+  }
+
+  const merged = { ...data };
+  const isAdmin =
+    isRequestedAdmin ||
+    merged.isAdmin === true ||
+    (typeof merged.role === 'string' && merged.role.toLowerCase() === 'administrator');
+
+  if (isAdmin && !Array.isArray(merged.segments)) {
+    merged.segments = ['Admin'];
+  }
+
+  if (isAdmin && Array.isArray(merged.segments) && !merged.segments.includes('Admin')) {
+    merged.segments = Array.from(new Set([...merged.segments, 'Admin']));
+    await safeUpdate({ segments: merged.segments, updatedAt: serverTimestamp() }, 'Unable to sync admin segments');
+  }
+
+  if (isAdmin && merged.vipTier !== 'Executive') {
+    await safeUpdate({ vipTier: 'Executive', updatedAt: serverTimestamp() }, 'Unable to sync admin vip tier');
+    merged.vipTier = 'Executive';
+  }
+
+  if (isAdmin && (typeof merged.role !== 'string' || merged.role.toLowerCase() !== 'administrator')) {
+    await safeUpdate({ role: 'Administrator', updatedAt: serverTimestamp() }, 'Unable to sync admin role');
+    merged.role = 'Administrator';
+  }
+
+  if (isAdmin && user.email && merged.email !== user.email) {
+    await safeUpdate({ email: user.email, updatedAt: serverTimestamp() }, 'Unable to sync admin email to profile');
+    merged.email = user.email;
+  }
+
+  try {
+    await updateDoc(userRef, { lastLoginAt: serverTimestamp() }, { merge: true });
+  } catch (error) {
+    console.warn('Unable to update lastLoginAt', error);
+  }
+
+  return {
+    id: user.uid,
+    displayName: merged.displayName || baseDisplayName || 'Administrator',
+    email: merged.email || user.email || '',
+    isAdmin,
+  };
+}
+
+function subscribeToUsers(db) {
+  if (!db) {
+    console.warn('Firestore instance missing. Skipping realtime user subscription.');
+    return;
+  }
+
+  const usersRef = collection(db, 'users');
+  const orderedQuery = query(usersRef, orderBy('updatedAt', 'desc'));
+
+  const attach = (targetRef, isFallback) => {
+    const unsubscribe = onSnapshot(
+      targetRef,
+      snapshot => {
+        ingestUserSnapshot(snapshot, isFallback);
+      },
+      error => {
+        const code = error?.code;
+        if (code === 'failed-precondition') {
+          console.warn('User stream missing index. Switching to fallback ordering.', error);
+          toast.show('Realtime ordering requires an index. Showing basic ordering for now.', 'warning');
+          unsubscribe();
+          if (!isFallback) {
+            attach(usersRef, true);
+          }
+          return;
+        }
+        console.error('User snapshot error', error);
+        toast.show('Realtime updates interrupted. Attempting to reconnect…', 'danger');
+        unsubscribe();
+        if (!isFallback) {
+          attach(usersRef, true);
+        }
+      }
+    );
+    state.usersUnsub = unsubscribe;
+  };
+
+  try {
+    attach(orderedQuery, false);
+  } catch (error) {
+    console.warn('Falling back to unordered user stream', error);
+    attach(usersRef, true);
+  }
+}
+
+function ingestUserSnapshot(snapshot, isFallback = false) {
+  if (!snapshot) {
+    return;
+  }
+  const records = snapshot.docs.map(docSnap => normalizeUserDoc(docSnap));
+  state.users = records;
+  state.usersFallback = isFallback;
+  updateVisibleUsers();
+  updateSummary();
+  state.lastSync = new Date();
+  updateLastSync();
+}
+
+function subscribeToAudit(db) {
+  if (!db) {
+    console.warn('Firestore instance missing. Skipping realtime audit subscription.');
+    return;
+  }
+  const auditRef = query(collection(db, 'adminAudit'), orderBy('createdAt', 'desc'), limit(25));
+  state.auditUnsub = onSnapshot(
+    auditRef,
+    snapshot => {
+      state.auditEntries = snapshot.docs.map(docSnap => normalizeAuditDoc(docSnap));
+      renderAudit();
+    },
+    error => {
+      console.error('Audit snapshot error', error);
+      toast.show('Audit feed disconnected. Use refresh to retry.', 'danger');
+    }
+  );
+}
+
+function subscribeToActivity(userId, force = false) {
+  if (!userId) {
+    if (typeof state.activityUnsub === 'function') {
+      state.activityUnsub();
+      state.activityUnsub = null;
+    }
+    state.userActivity = [];
+    renderActivity();
+    return;
+  }
+  const db = state.db || getFirestore();
+  if (!db) {
+    console.warn('Firestore unavailable. Skipping activity subscription.');
+    return;
+  }
+  const activityRef = query(collection(db, 'users', userId, 'activity'), orderBy('createdAt', 'desc'), limit(20));
+  if (state.activityUnsub && !force) {
+    return;
+  }
+  if (state.activityUnsub) {
+    state.activityUnsub();
+  }
+  state.activityUnsub = onSnapshot(
+    activityRef,
+    snapshot => {
+      state.userActivity = snapshot.docs.map(docSnap => normalizeActivityDoc(docSnap));
+      renderActivity();
+    },
+    error => {
+      console.error('Activity snapshot error', error);
+    }
+  );
+}
+
+async function fetchUsersOnce(dbOverride) {
+  const db = dbOverride || state.db || getFirestore();
+  if (!db) {
+    throw new Error('Firestore instance unavailable');
+  }
+  const usersRef = collection(db, 'users');
+  try {
+    const snapshot = await getDocs(query(usersRef, orderBy('updatedAt', 'desc')));
+    ingestUserSnapshot(snapshot, false);
+  } catch (error) {
+    const code = error?.code;
+    if (code === 'failed-precondition') {
+      console.warn('Falling back to unordered user fetch', error);
+      const fallbackSnapshot = await getDocs(usersRef);
+      ingestUserSnapshot(fallbackSnapshot, true);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function fetchAuditOnce(dbOverride) {
+  const db = dbOverride || state.db || getFirestore();
+  if (!db) {
+    throw new Error('Firestore instance unavailable');
+  }
+  const snapshot = await getDocs(query(collection(db, 'adminAudit'), orderBy('createdAt', 'desc'), limit(25)));
+  state.auditEntries = snapshot.docs.map(docSnap => normalizeAuditDoc(docSnap));
+  renderAudit();
+}
+
+function updateVisibleUsers() {
+  const filters = state.filters;
+  const search = filters.search;
+  const filtered = state.users
+    .filter(user => {
+      if (search) {
+        const segments = Array.isArray(user.segments) ? user.segments.join(' ').toLowerCase() : '';
+        if (
+          !user.name.toLowerCase().includes(search) &&
+          !(user.email || '').toLowerCase().includes(search) &&
+          !segments.includes(search)
+        ) {
+          return false;
+        }
+      }
+      if (filters.status !== 'all' && user.status !== filters.status) {
+        return false;
+      }
+      if (filters.role !== 'all' && user.role !== filters.role) {
+        return false;
+      }
+      if (filters.vip !== 'all' && user.vipTier !== filters.vip) {
+        return false;
+      }
+      return true;
+    })
+    .sort((a, b) => a.lastActiveMinutes - b.lastActiveMinutes);
+
+  state.visibleUsers = filtered;
+  if (!filtered.length) {
+    state.activeUserId = null;
+  } else if (!state.activeUserId || !filtered.some(user => user.id === state.activeUserId)) {
+    state.activeUserId = filtered[0].id;
+  }
+  renderTable();
+  renderDetail();
+  if (state.activeUserId) {
+    subscribeToActivity(state.activeUserId);
+  } else {
+    subscribeToActivity(null);
+  }
+  if (elements.tableCount) {
+    elements.tableCount.textContent = filtered.length.toLocaleString();
+  }
+  if (elements.tableTotal) {
+    elements.tableTotal.textContent = state.users.length.toLocaleString();
+  }
+}
+
+function renderTable() {
+  if (!elements.tableBody) {
+    return;
+  }
+  if (!state.visibleUsers.length) {
+    elements.tableBody.innerHTML =
+      '<tr><td colspan="6" class="px-4 py-6 text-center text-sm text-gray-400">No matching players. Adjust filters or invite a new user.</td></tr>';
+    return;
+  }
+
+  const rows = state.visibleUsers
+    .map(user => {
+      const isActive = user.id === state.activeUserId;
+      const badgeStatus = statusStyles[user.status] || 'border border-gray-700 text-gray-300 bg-gray-800/40';
+      const vipBadge = vipStyles[user.vipTier] || 'border border-gray-700 text-gray-300 bg-gray-800/40';
+      const riskBadge = riskStyles[user.riskLevel] || 'border border-gray-700 text-gray-300 bg-gray-800/40';
+      const roleBadge = roleStyles[user.role] || 'border border-gray-700 text-gray-300 bg-gray-800/40';
+      const statusIndicator = statusIndicators[user.status] || 'bg-gray-500';
+      const rowClasses = [
+        'group',
+        'cursor-pointer',
+        'transition',
+        'border-l-2',
+        'border-transparent',
+        'hover:bg-gray-900/40',
+        isActive ? 'bg-primary/5 border-primary/70 shadow-[0_0_20px_rgba(0,194,255,0.12)]' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const segments = Array.isArray(user.segments)
+        ? user.segments
+            .map(segment => `
+                <span class="text-[11px] uppercase tracking-[0.2em] text-gray-500 bg-gray-800/70 border border-gray-700/80 rounded-full px-2 py-0.5">${escapeHtml(
+                  segment
+                )}</span>
+              `)
+            .join('')
+        : '';
+      const joinedLabel = user.createdAt
+        ? user.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+        : 'Unknown';
+      return `
+        <tr data-user-row data-user-id="${user.id}" class="${rowClasses}">
+          <td class="px-4 py-3">
+            <div class="flex items-start gap-3">
+              <div class="relative">
+                <span class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-primary/30 to-secondary/30 font-semibold text-white">${getInitials(
+                  user.name
+                )}</span>
+                <span class="absolute -bottom-1 -right-1 h-2.5 w-2.5 rounded-full ${statusIndicator} ring-2 ring-gray-900"></span>
+              </div>
+              <div>
+                <p class="font-semibold text-white">${escapeHtml(user.name)}</p>
+                <p class="text-xs text-gray-400">${escapeHtml(user.email || '—')}</p>
+                <div class="flex flex-wrap gap-1 mt-1">${segments}</div>
+              </div>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            <span class="badge ${badgeStatus}">${escapeHtml(user.status)}</span>
+          </td>
+          <td class="px-4 py-3">
+            <div class="space-y-1">
+              <p class="font-semibold text-white">${formatCurrency(user.balance)}</p>
+              <p class="text-[11px] text-gray-500">Payouts: ${formatCurrency(user.lifetimePayouts)}</p>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            <div class="flex flex-col gap-2">
+              <span class="badge ${vipBadge}">${escapeHtml(user.vipTier)} VIP</span>
+              <span class="badge ${roleBadge}">${escapeHtml(user.role)}</span>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            <p class="font-medium text-white">${escapeHtml(user.lastActive)}</p>
+            <p class="text-[11px] text-gray-500">Joined ${joinedLabel}</p>
+          </td>
+          <td class="px-4 py-3">
+            <span class="badge ${riskBadge}">${escapeHtml(user.riskLevel)}</span>
+          </td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  elements.tableBody.innerHTML = rows;
+  elements.tableBody.querySelectorAll('[data-user-row]').forEach(row => {
+    row.addEventListener('click', () => {
+      const id = row.getAttribute('data-user-id');
+      if (!id) {
+        return;
+      }
+      state.activeUserId = id;
+      state.formDirty = false;
+      renderTable();
+      renderDetail();
+      subscribeToActivity(id, true);
+    });
+  });
+}
+
+function renderDetail() {
+  const user = state.users.find(item => item.id === state.activeUserId) || null;
+  if (!elements.detailPanel || !elements.selectedView || !elements.emptyView) {
+    return;
+  }
+
+  if (!user) {
+    elements.selectedView.classList.add('hidden');
+    elements.emptyView.classList.remove('hidden');
+    state.formInitialData = null;
+    state.userActivity = [];
+    renderActivity();
+    return;
+  }
+
+  elements.selectedView.classList.remove('hidden');
+  elements.emptyView.classList.add('hidden');
+
+  const detail = elements.detail;
+  if (detail.name) detail.name.textContent = user.name;
+  if (detail.email) {
+    detail.email.textContent = user.email || '—';
+    detail.email.setAttribute('href', user.email ? `mailto:${user.email}` : '#');
+  }
+  if (detail.id) detail.id.textContent = user.id;
+  if (detail.role) {
+    detail.role.textContent = user.role;
+    detail.role.className = `badge ${roleStyles[user.role] || 'border border-gray-700 text-gray-300 bg-gray-800/40'}`;
+  }
+  if (detail.status) {
+    detail.status.textContent = user.status;
+    detail.status.className = `badge ${statusStyles[user.status] || 'border border-gray-700 text-gray-300 bg-gray-800/40'}`;
+  }
+  if (detail.vip) {
+    detail.vip.textContent = `${user.vipTier}`;
+    detail.vip.className = `badge ${vipStyles[user.vipTier] || 'border border-gray-700 text-gray-300 bg-gray-800/40'}`;
+  }
+  if (detail.balance) detail.balance.textContent = formatCurrency(user.balance);
+  if (detail.deposits) detail.deposits.textContent = formatCurrency(user.lifetimeDeposits);
+  if (detail.wagered) detail.wagered.textContent = formatCurrency(user.lifetimeWagered);
+  if (detail.payouts) detail.payouts.textContent = formatCurrency(user.lifetimePayouts);
+  if (detail.lastActive) detail.lastActive.textContent = user.lastActive;
+  if (detail.location) detail.location.textContent = user.location || '—';
+  if (detail.tags) {
+    detail.tags.innerHTML = Array.isArray(user.segments) && user.segments.length
+      ? user.segments
+          .map(segment => `
+              <span class="text-[11px] uppercase tracking-[0.3em] text-gray-500 bg-gray-800/70 border border-gray-700/80 rounded-full px-2 py-0.5">${escapeHtml(
+                segment
+              )}</span>
+            `)
+          .join('')
+      : '<span class="text-[11px] uppercase tracking-[0.3em] text-gray-600">No tags</span>';
+  }
+  if (detail.cooldown && detail.cooldownText) {
+    if (user.cooldownEnds) {
+      detail.cooldown.classList.remove('hidden');
+      detail.cooldownText.textContent = user.cooldownEnds;
+    } else {
+      detail.cooldown.classList.add('hidden');
+      detail.cooldownText.textContent = '';
+    }
+  }
+
+  if (!state.formDirty) {
+    applyFormValues(user);
+  }
+  state.formInitialData = extractFormValues();
+}
+
+function applyFormValues(user) {
+  const form = elements.userForm;
+  if (!form) {
+    return;
+  }
+  form.userName.value = user.name || '';
+  form.userEmail.value = user.email || '';
+  if (form.userRole) selectOption(form.userRole, user.role || 'Player');
+  if (form.userStatus) selectOption(form.userStatus, user.status || 'Active');
+  if (form.userVip) selectOption(form.userVip, user.vipTier || 'Bronze');
+  if (form.userRisk) selectOption(form.userRisk, user.riskLevel || 'Low');
+  if (form.userLocation) form.userLocation.value = user.location || '';
+  if (form.userBalance) form.userBalance.value = Number(user.balance || 0).toFixed(2);
+  if (form.userDeposits) form.userDeposits.value = Number(user.lifetimeDeposits || 0).toFixed(2);
+  if (form.userWagered) form.userWagered.value = Number(user.lifetimeWagered || 0).toFixed(2);
+  if (form.userPayouts) form.userPayouts.value = Number(user.lifetimePayouts || 0).toFixed(2);
+  if (form.userTwoFactor) form.userTwoFactor.checked = Boolean(user.twoFactor);
+  if (form.userEmailVerified) form.userEmailVerified.checked = Boolean(user.emailVerified);
+  if (form.userPayoutHold) form.userPayoutHold.checked = Boolean(user.payoutHold);
+  if (form.userNotes) form.userNotes.value = user.notes || '';
+  state.formDirty = false;
+}
+
+function extractFormValues() {
+  const form = elements.userForm;
+  if (!form) {
+    return null;
+  }
+  return {
+    name: form.userName?.value?.trim() || '',
+    email: form.userEmail?.value?.trim() || '',
+    role: form.userRole?.value || 'Player',
+    status: form.userStatus?.value || 'Active',
+    vipTier: form.userVip?.value || 'Bronze',
+    riskLevel: form.userRisk?.value || 'Low',
+    location: form.userLocation?.value?.trim() || '',
+    balance: Number.parseFloat(form.userBalance?.value || '0') || 0,
+    lifetimeDeposits: Number.parseFloat(form.userDeposits?.value || '0') || 0,
+    lifetimeWagered: Number.parseFloat(form.userWagered?.value || '0') || 0,
+    lifetimePayouts: Number.parseFloat(form.userPayouts?.value || '0') || 0,
+    twoFactor: Boolean(form.userTwoFactor?.checked),
+    emailVerified: Boolean(form.userEmailVerified?.checked),
+    payoutHold: Boolean(form.userPayoutHold?.checked),
+    notes: form.userNotes?.value?.trim() || '',
+  };
+}
+
+function resetFormToInitial() {
+  if (!state.formInitialData) {
+    return;
+  }
+  const form = elements.userForm;
+  if (!form) {
+    return;
+  }
+  const values = state.formInitialData;
+  form.userName.value = values.name;
+  form.userEmail.value = values.email;
+  if (form.userRole) selectOption(form.userRole, values.role);
+  if (form.userStatus) selectOption(form.userStatus, values.status);
+  if (form.userVip) selectOption(form.userVip, values.vipTier);
+  if (form.userRisk) selectOption(form.userRisk, values.riskLevel);
+  if (form.userLocation) form.userLocation.value = values.location;
+  if (form.userBalance) form.userBalance.value = Number(values.balance || 0).toFixed(2);
+  if (form.userDeposits) form.userDeposits.value = Number(values.lifetimeDeposits || 0).toFixed(2);
+  if (form.userWagered) form.userWagered.value = Number(values.lifetimeWagered || 0).toFixed(2);
+  if (form.userPayouts) form.userPayouts.value = Number(values.lifetimePayouts || 0).toFixed(2);
+  if (form.userTwoFactor) form.userTwoFactor.checked = Boolean(values.twoFactor);
+  if (form.userEmailVerified) form.userEmailVerified.checked = Boolean(values.emailVerified);
+  if (form.userPayoutHold) form.userPayoutHold.checked = Boolean(values.payoutHold);
+  if (form.userNotes) form.userNotes.value = values.notes;
+  state.formDirty = false;
+}
+
+async function handleUserFormSubmit(event, auth, db) {
+  event.preventDefault();
+  if (!state.activeUserId) {
+    toast.show('Select a player first.', 'warning');
+    return;
+  }
+  const current = state.users.find(item => item.id === state.activeUserId);
+  if (!current) {
+    toast.show('Player data unavailable. Wait for synchronization.', 'warning');
+    return;
+  }
+  const values = extractFormValues();
+  const previous = state.formInitialData || {};
+  const updates = {};
+  const changes = [];
+
+  const diffFields = ['name', 'email', 'role', 'status', 'vipTier', 'riskLevel', 'location', 'notes'];
+  diffFields.forEach(field => {
+    if (values[field] !== previous[field]) {
+      switch (field) {
+        case 'name':
+          updates.displayName = values.name;
+          break;
+        case 'email':
+          updates.email = values.email;
+          break;
+        case 'role':
+          updates.role = values.role;
+          break;
+        case 'status':
+          updates.status = values.status;
+          break;
+        case 'vipTier':
+          updates.vipTier = values.vipTier;
+          break;
+        case 'riskLevel':
+          updates.riskLevel = values.riskLevel;
+          break;
+        case 'location':
+          updates.location = values.location;
+          break;
+        case 'notes':
+          updates.notes = values.notes;
+          break;
+        default:
+          break;
+      }
+      changes.push({ field, before: previous[field], after: values[field] });
+    }
+  });
+
+  const numericFields = [
+    { key: 'balance', field: 'balance' },
+    { key: 'lifetimeDeposits', field: 'lifetimeDeposits' },
+    { key: 'lifetimeWagered', field: 'lifetimeWagered' },
+    { key: 'lifetimePayouts', field: 'lifetimePayouts' },
+  ];
+
+  numericFields.forEach(({ key, field }) => {
+    const sanitized = Math.max(0, Number(values[key]) || 0);
+    if (sanitized !== Math.max(0, Number(previous[key]) || 0)) {
+      updates[field] = sanitized;
+      changes.push({ field: key, before: previous[key], after: sanitized });
+    }
+  });
+
+  if (values.twoFactor !== previous.twoFactor) {
+    updates.twoFactor = values.twoFactor;
+    changes.push({ field: 'twoFactor', before: previous.twoFactor, after: values.twoFactor });
+  }
+  if (values.emailVerified !== previous.emailVerified) {
+    updates.emailVerified = values.emailVerified;
+    changes.push({ field: 'emailVerified', before: previous.emailVerified, after: values.emailVerified });
+  }
+  if (values.payoutHold !== previous.payoutHold) {
+    updates.payoutHold = values.payoutHold;
+    changes.push({ field: 'payoutHold', before: previous.payoutHold, after: values.payoutHold });
+  }
+
+  if (!changes.length) {
+    toast.show('No changes detected.', 'info');
+    return;
+  }
+
+  const userRef = doc(db, 'users', current.id);
+
+  try {
+    if (Object.prototype.hasOwnProperty.call(updates, 'balance')) {
+      const sanitizedBalance = updates.balance;
+      delete updates.balance;
+      await runTransaction(db, async transaction => {
+        const snapshot = await transaction.get(userRef);
+        if (!snapshot.exists()) {
+          transaction.set(userRef, {
+            balance: sanitizedBalance,
+            displayName: values.name,
+            email: values.email,
+            updatedAt: serverTimestamp(),
+          });
+        } else {
+          transaction.update(userRef, {
+            balance: sanitizedBalance,
+            updatedAt: serverTimestamp(),
+          });
+        }
+      });
+      updates.balance = sanitizedBalance;
+    }
+    updates.updatedAt = serverTimestamp();
+    await updateDoc(userRef, updates);
+
+    await logAuditEvent(db, {
+      userId: current.id,
+      userName: current.name,
+      userEmail: current.email,
+      action: 'Profile updated',
+      description: `Updated ${changes.length} field${changes.length === 1 ? '' : 's'} for ${current.name}.`,
+      tone: 'emerald',
+      metadata: { changes },
+    });
+
+    toast.show('Profile saved.', 'success');
+    state.formDirty = false;
+    state.formInitialData = values;
+  } catch (error) {
+    console.error('Failed to save profile', error);
+    toast.show('Unable to save changes. Please try again.', 'danger');
+  }
+}
+
+function renderActivity() {
+  if (!elements.activityList) {
+    return;
+  }
+  if (!state.userActivity.length) {
+    elements.activityList.innerHTML = '<li class="text-xs text-gray-500">No recent activity recorded yet.</li>';
+    return;
+  }
+  elements.activityList.innerHTML = state.userActivity
+    .map(item => `
+      <li class="rounded-2xl border border-gray-800/80 bg-black/30 px-4 py-3">
+        <p class="text-sm font-medium text-white">${escapeHtml(item.description)}</p>
+        <p class="text-[11px] text-gray-500 mt-1 uppercase tracking-[0.3em]">${escapeHtml(item.timestamp)}</p>
+      </li>
+    `)
+    .join('');
+}
+
+function renderAudit() {
+  if (!elements.auditList) {
+    return;
+  }
+  if (!state.auditEntries.length) {
+    elements.auditList.innerHTML = '<p class="text-sm text-gray-500">No audit events recorded yet.</p>';
+    return;
+  }
+  elements.auditList.innerHTML = state.auditEntries
+    .map((entry, index) => {
+      const tone = toneStyles[entry.tone] || toneStyles.emerald;
+      const isLast = index === state.auditEntries.length - 1;
+      const metadataSegments = [];
+      if (entry.userName) {
+        metadataSegments.push(escapeHtml(entry.userName));
+      }
+      if (entry.userEmail) {
+        metadataSegments.push(escapeHtml(entry.userEmail));
+      }
+      if (entry.performedBy) {
+        metadataSegments.push(`by ${escapeHtml(entry.performedBy)}`);
+      }
+      metadataSegments.push(entry.timestamp);
+      return `
+        <div class="flex items-start gap-4">
+          <div class="relative flex flex-col items-center">
+            <span class="flex h-10 w-10 items-center justify-center rounded-full ${tone} text-base font-semibold">${escapeHtml(
+              entry.icon
+            )}</span>
+            <span class="${isLast ? 'hidden' : 'block'} h-full w-px bg-gray-800/70 mt-2"></span>
+          </div>
+          <div class="flex-1 space-y-1 border border-gray-800/70 bg-black/30 rounded-2xl px-4 py-3">
+            <p class="text-sm font-semibold text-white">${escapeHtml(entry.action)}</p>
+            <p class="text-xs text-gray-400">${escapeHtml(entry.description)}</p>
+            <div class="flex flex-wrap gap-3 text-[11px] uppercase tracking-[0.25em] text-gray-500">
+              ${metadataSegments.map(segment => `<span>${segment}</span>`).join('')}
+            </div>
+          </div>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function updateSummary() {
+  const totalUsers = state.users.length;
+  const totalBalance = state.users.reduce((sum, user) => sum + (Number(user.balance) || 0), 0);
+  const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const newSignups = state.users.filter(user => user.createdAt && user.createdAt.getTime() >= weekAgo).length;
+  const adminCount = state.users.filter(user => user.role === 'Administrator' || user.isAdmin).length;
+  const activeNow = state.users.filter(user => user.lastActiveMinutes <= 15).length;
+  const flagged = state.users.filter(
+    user =>
+      user.status === 'Under Review' ||
+      user.status === 'Suspended' ||
+      user.payoutHold ||
+      user.riskLevel === 'Critical'
+  ).length;
+
+  if (elements.summary.totalUsers) elements.summary.totalUsers.textContent = totalUsers.toLocaleString();
+  if (elements.summary.totalBalance) elements.summary.totalBalance.textContent = formatCurrency(totalBalance);
+  if (elements.summary.newSignups) elements.summary.newSignups.textContent = newSignups.toLocaleString();
+  if (elements.summary.adminCount) elements.summary.adminCount.textContent = adminCount.toLocaleString();
+  if (elements.summary.activeNow) elements.summary.activeNow.textContent = activeNow.toLocaleString();
+  if (elements.summary.flagged) elements.summary.flagged.textContent = flagged.toLocaleString();
+}
+
+function updateLastSync() {
+  if (!elements.lastSyncTarget) {
+    return;
+  }
+  if (!state.lastSync) {
+    elements.lastSyncTarget.textContent = '—';
+    return;
+  }
+  elements.lastSyncTarget.textContent = state.lastSync.toLocaleString();
+}
+
+async function logAuditEvent(db, { userId, userName, userEmail, action, description, tone = 'emerald', metadata = {} }) {
+  const payload = {
+    userId: userId || null,
+    userName: userName || null,
+    userEmail: userEmail || null,
+    action,
+    description,
+    tone,
+    metadata,
+    performedBy: state.adminProfile?.displayName || state.adminProfile?.email || null,
+    performedByEmail: state.adminProfile?.email || null,
+    performedByUid: state.adminProfile?.id || state.authUser?.uid || null,
+    icon: selectAuditIcon(tone, action),
+    createdAt: serverTimestamp(),
+  };
+  await addDoc(collection(db, 'adminAudit'), payload);
+  if (userId) {
+    await addDoc(collection(db, 'users', userId, 'activity'), {
+      description,
+      action,
+      tone,
+      metadata,
+      performedBy: payload.performedBy,
+      performedByEmail: payload.performedByEmail,
+      timestamp: serverTimestamp(),
+    });
+  }
+}
+
+function selectAuditIcon(tone, action) {
+  if (tone === 'rose' || /suspend/i.test(action)) {
+    return '⛔';
+  }
+  if (tone === 'amber' || /call|wellbeing/i.test(action)) {
+    return '📞';
+  }
+  if (tone === 'sky' || /imperson/i.test(action)) {
+    return '🛠️';
+  }
+  if (tone === 'violet' || /summary/i.test(action)) {
+    return '📄';
+  }
+  return '✅';
+}
+
+function normalizeUserDoc(snapshot) {
+  const data = snapshot.data() || {};
+  const createdAt = resolveTimestamp(data.createdAt);
+  const lastLoginAt = resolveTimestamp(data.lastLoginAt);
+  const updatedAt = resolveTimestamp(data.updatedAt);
+  const lastActiveAt = resolveTimestamp(data.lastActiveAt) || lastLoginAt || updatedAt || createdAt;
+  const lastActiveMinutes = lastActiveAt ? Math.max(0, Math.round((Date.now() - lastActiveAt.getTime()) / 60000)) : 999999;
+
+  return {
+    id: snapshot.id,
+    name: data.displayName || data.name || (data.email ? data.email.split('@')[0] : 'Player'),
+    email: data.email || '',
+    balance: typeof data.balance === 'number' ? data.balance : 0,
+    status: data.status || 'Active',
+    role: data.role || (data.isAdmin ? 'Administrator' : 'Player'),
+    vipTier: data.vipTier || 'Bronze',
+    riskLevel: data.riskLevel || 'Low',
+    lifetimeDeposits: typeof data.lifetimeDeposits === 'number' ? data.lifetimeDeposits : 0,
+    lifetimeWagered: typeof data.lifetimeWagered === 'number' ? data.lifetimeWagered : 0,
+    lifetimePayouts: typeof data.lifetimePayouts === 'number' ? data.lifetimePayouts : 0,
+    twoFactor: Boolean(data.twoFactor),
+    emailVerified: Boolean(data.emailVerified),
+    payoutHold: Boolean(data.payoutHold),
+    notes: data.notes || '',
+    location: data.location || '',
+    segments: Array.isArray(data.segments) ? data.segments : Array.isArray(data.tags) ? data.tags : [],
+    cooldownEnds: data.cooldownEnds || null,
+    createdAt,
+    lastActiveAt,
+    lastActiveMinutes,
+    lastActive: lastActiveAt ? timeAgo(lastActiveAt) : '—',
+    isAdmin: data.isAdmin === true,
+  };
+}
+
+function normalizeAuditDoc(snapshot) {
+  const data = snapshot.data() || {};
+  const createdAt = resolveTimestamp(data.createdAt) || new Date();
+  return {
+    id: snapshot.id,
+    userId: data.userId || null,
+    userName: data.userName || null,
+    userEmail: data.userEmail || null,
+    action: data.action || 'Update',
+    description: data.description || '—',
+    tone: data.tone || 'emerald',
+    metadata: data.metadata || {},
+    performedBy: data.performedBy || data.performedByEmail || 'System',
+    icon: data.icon || selectAuditIcon(data.tone, data.action || ''),
+    timestamp: createdAt.toLocaleString(),
+  };
+}
+
+function normalizeActivityDoc(snapshot) {
+  const data = snapshot.data() || {};
+  const createdAt = resolveTimestamp(data.timestamp || data.createdAt) || new Date();
+  return {
+    id: snapshot.id,
+    description: data.description || data.action || 'Activity recorded',
+    timestamp: timeAgo(createdAt),
+  };
+}
+
+function createToast() {
+  const container = elements.toast;
+  const messageEl = elements.toastMessage;
+  if (!container || !messageEl) {
+    return {
+      show() {},
+      hide() {},
+    };
+  }
+  let timeoutId = null;
+  const toneClasses = {
+    success: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+    danger: 'border-rose-500/40 bg-rose-500/10 text-rose-200',
+    warning: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+    info: 'border-sky-500/40 bg-sky-500/10 text-sky-200',
+  };
+
+  function hide() {
+    container.classList.add('hidden');
+    container.classList.remove(...Object.values(toneClasses));
+    messageEl.textContent = '';
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  }
+
+  function show(message, tone = 'success') {
+    container.classList.remove('hidden');
+    container.classList.remove(...Object.values(toneClasses));
+    const toneClass = toneClasses[tone] || toneClasses.success;
+    container.classList.add(toneClass);
+    messageEl.textContent = message;
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = window.setTimeout(() => hide(), 6000);
+  }
+
+  return { show, hide };
+}
+
+function createGateController() {
+  const root = document.querySelector('[data-admin-gate]');
+  if (!root) {
+    return {
+      showLoading() {},
+      showLogin() {},
+      showUnauthorized() {},
+      showError() {},
+      close() {},
+      loginForm: null,
+      loginEmail: null,
+      loginPassword: null,
+      loginError: null,
+      loginSubmit: null,
+      resetButton: null,
+      retryButton: null,
+    };
+  }
+  const screens = new Map();
+  root.querySelectorAll('[data-gate-screen]').forEach(screen => {
+    screens.set(screen.getAttribute('data-gate-screen'), screen);
+  });
+  const loginForm = root.querySelector('[data-admin-login-form]');
+  const loginEmail = root.querySelector('[data-admin-login-email]');
+  const loginPassword = root.querySelector('[data-admin-login-password]');
+  const loginError = root.querySelector('[data-admin-login-error]');
+  const loginSubmit = root.querySelector('[data-admin-login-submit]');
+  const resetButton = root.querySelector('[data-admin-login-reset]');
+  const retryButton = root.querySelector('[data-admin-retry]');
+  const unauthorizedMessage = root.querySelector('[data-admin-unauthorized-message]');
+  const errorMessage = root.querySelector('[data-admin-error-message]');
+
+  function setScreen(name) {
+    root.classList.remove('hidden');
+    screens.forEach((screen, key) => {
+      if (key === name) {
+        screen.classList.remove('hidden');
+      } else {
+        screen.classList.add('hidden');
+      }
+    });
+  }
+
+  function close() {
+    root.classList.add('hidden');
+  }
+
+  return {
+    showLoading() {
+      setScreen('loading');
+    },
+    showLogin() {
+      if (loginEmail && !loginEmail.value) {
+        loginEmail.value = ADMIN_EMAIL;
+      }
+      if (loginError) {
+        loginError.classList.add('hidden');
+        loginError.textContent = '';
+      }
+      setScreen('login');
+    },
+    showUnauthorized(message) {
+      if (unauthorizedMessage) {
+        unauthorizedMessage.textContent = message;
+      }
+      setScreen('unauthorized');
+    },
+    showError(message) {
+      if (errorMessage) {
+        errorMessage.textContent = message;
+      }
+      setScreen('error');
+    },
+    close,
+    loginForm,
+    loginEmail,
+    loginPassword,
+    loginError,
+    loginSubmit,
+    resetButton,
+    retryButton,
+  };
+}
+
+function initNavigation() {
+  const balanceTargets = Array.from(document.querySelectorAll('[data-balance]')).map(element => ({
+    element,
+    fallback: element.getAttribute('data-default-balance') || element.textContent?.trim() || '0.00',
+  }));
+
+  function updateBalanceFromStorage() {
+    if (!balanceTargets.length) {
+      return;
+    }
+    let storedBalance = null;
+    try {
+      storedBalance = window.localStorage.getItem(BALANCE_STORAGE_KEY);
+    } catch (error) {
+      storedBalance = null;
+    }
+    if (storedBalance == null) {
+      balanceTargets.forEach(({ element, fallback }) => {
+        element.textContent = fallback;
+      });
+      return;
+    }
+    const numericValue = Number.parseFloat(storedBalance);
+    if (Number.isFinite(numericValue)) {
+      const formatted = formatCurrency(numericValue);
+      balanceTargets.forEach(({ element }) => {
+        element.textContent = formatted;
+      });
+    } else {
+      balanceTargets.forEach(({ element, fallback }) => {
+        element.textContent = fallback;
+      });
+    }
+  }
+
+  updateBalanceFromStorage();
+  window.addEventListener('storage', event => {
+    if (event.key === BALANCE_STORAGE_KEY) {
+      updateBalanceFromStorage();
+    }
+  });
+  document.addEventListener('neonCasinoBalanceUpdated', updateBalanceFromStorage);
+
+  const toggleButton = document.querySelector('[data-mobile-toggle]');
+  const mobileMenu = document.querySelector('[data-mobile-menu]');
+  if (toggleButton && mobileMenu) {
+    const setMenuState = isOpen => {
+      mobileMenu.classList.toggle('hidden', !isOpen);
+      toggleButton.setAttribute('aria-expanded', String(isOpen));
+      const openIcon = toggleButton.querySelector('[data-icon-open]');
+      const closedIcon = toggleButton.querySelector('[data-icon-closed]');
+      if (openIcon) openIcon.classList.toggle('hidden', !isOpen);
+      if (closedIcon) closedIcon.classList.toggle('hidden', isOpen);
+      document.body.classList.toggle('overflow-hidden', isOpen);
+    };
+
+    toggleButton.addEventListener('click', () => {
+      const currentlyOpen = !mobileMenu.classList.contains('hidden');
+      setMenuState(!currentlyOpen);
+    });
+
+    mobileMenu.querySelectorAll('a, button').forEach(el => {
+      el.addEventListener('click', () => setMenuState(false));
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        setMenuState(false);
+      }
+    });
+
+    const mq = window.matchMedia('(min-width: 768px)');
+    const handleMediaChange = event => {
+      if (event.matches) {
+        setMenuState(false);
+      }
+    };
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', handleMediaChange);
+    } else if (typeof mq.addListener === 'function') {
+      mq.addListener(handleMediaChange);
+    }
+
+    setMenuState(false);
+  }
+}
+
+function initAOSAndFeather() {
+  if (window.AOS) {
+    window.AOS.init({ duration: 800, easing: 'ease-in-out', once: true });
+  }
+  if (window.feather) {
+    window.feather.replace();
+  }
+}
+
+function setNavSignedIn(profile) {
+  elements.nav.signedIn.forEach(el => el.classList.remove('hidden'));
+  elements.nav.signedOut.forEach(el => el.classList.add('hidden'));
+  const name = profile.displayName || profile.email || 'Administrator';
+  elements.nav.identityName.forEach(el => {
+    el.textContent = name;
+  });
+  elements.nav.identityEmail.forEach(el => {
+    el.textContent = profile.email || '';
+  });
+}
+
+function setNavSignedOut() {
+  elements.nav.signedOut.forEach(el => el.classList.remove('hidden'));
+  elements.nav.signedIn.forEach(el => el.classList.add('hidden'));
+}
+
+function readFirebaseConfig() {
+  const configEl = document.getElementById('firebase-config');
+  if (!configEl) {
+    console.warn('Firebase configuration script tag not found.');
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(configEl.textContent || '{}');
+    return validateFirebaseConfig(parsed);
+  } catch (error) {
+    console.error('Failed to parse Firebase config', error);
+    return null;
+  }
+}
+
+function validateFirebaseConfig(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const config = {};
+  Object.keys(raw).forEach(key => {
+    const value = raw[key];
+    if (value != null) {
+      config[key] = typeof value === 'string' ? value.trim() : value;
+    }
+  });
+  const required = ['apiKey', 'authDomain', 'projectId'];
+  const missingKey = required.find(key => !config[key]);
+  if (missingKey) {
+    console.warn(`Firebase configuration missing required key: ${missingKey}`);
+    return null;
+  }
+  return config;
+}
+
+function selectOption(select, value) {
+  if (!select) {
+    return;
+  }
+  const option = Array.from(select.options).find(opt => opt.value === value);
+  if (option) {
+    select.value = option.value;
+  } else if (select.options.length) {
+    select.value = select.options[0].value;
+  }
+}
+
+function formatCurrency(value) {
+  const numeric = Number(value) || 0;
+  return `$${numeric.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function getInitials(name) {
+  if (!name) {
+    return 'NC';
+  }
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0][0] || ''}${parts[parts.length - 1][0] || ''}`.toUpperCase();
+}
+
+function resolveTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+  if (typeof value.toDate === 'function') {
+    return value.toDate();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function timeAgo(date) {
+  if (!(date instanceof Date)) {
+    return '—';
+  }
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 45) {
+    return 'Just now';
+  }
+  if (seconds < 90) {
+    return '1 minute ago';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 7) {
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+  }
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) {
+    return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return `${months} month${months === 1 ? '' : 's'} ago`;
+  }
+  const years = Math.floor(days / 365);
+  return `${years} year${years === 1 ? '' : 's'} ago`;
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function exportUsersToCsv() {
+  if (!state.visibleUsers.length) {
+    toast.show('Nothing to export. Try adjusting your filters first.', 'info');
+    return;
+  }
+  const headers = [
+    'User ID',
+    'Name',
+    'Email',
+    'Role',
+    'Status',
+    'VIP Tier',
+    'Risk Level',
+    'Balance',
+    'Lifetime Deposits',
+    'Lifetime Wagered',
+    'Lifetime Payouts',
+    'Two Factor',
+    'Email Verified',
+    'Payout Hold',
+    'Last Active',
+  ];
+  const rows = state.visibleUsers.map(user => [
+    user.id,
+    user.name,
+    user.email,
+    user.role,
+    user.status,
+    user.vipTier,
+    user.riskLevel,
+    user.balance,
+    user.lifetimeDeposits,
+    user.lifetimeWagered,
+    user.lifetimePayouts,
+    user.twoFactor ? 'Yes' : 'No',
+    user.emailVerified ? 'Yes' : 'No',
+    user.payoutHold ? 'Yes' : 'No',
+    user.lastActive,
+  ]);
+  const csvContent = [headers, ...rows]
+    .map(row => row.map(value => `"${String(value ?? '').replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `neon-casino-users-${Date.now()}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  toast.show('CSV export generated.', 'success');
+}
+

--- a/auth.html
+++ b/auth.html
@@ -71,10 +71,10 @@ CASINO</span>
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-white hover:text-primary transition">Home</a>
                     <a href="games.html" class="text-white hover:text-primary transition">Games</a>
-
-                    <a href="#" class="text-white hover:text-primary transition">Promotions</a>
-                    <a href="#" class="text-white hover:text-primary transition">Provably Fair</a>
-                    <a href="#" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+                    <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+                    <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
                 </div>
                 <div class="hidden md:flex items-center space-x-4">
                     <div class="bg-gray-800 rounded-full px-4 py-1.5 flex items-center space-x-2">
@@ -93,9 +93,10 @@ CASINO</span>
                 <div class="flex flex-col space-y-3">
                     <a href="index.html" class="text-white hover:text-primary transition">Home</a>
                     <a href="games.html" class="text-white hover:text-primary transition">Games</a>
-                    <a href="#" class="text-white hover:text-primary transition">Promotions</a>
-                    <a href="#" class="text-white hover:text-primary transition">Provably Fair</a>
-                    <a href="#" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+                    <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+                    <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
                 </div>
                 <div class="space-y-3 border-t border-gray-800 pt-4">
                     <div class="space-y-2">
@@ -374,6 +375,7 @@ CASINO</span>
             doc,
             getDoc,
             setDoc,
+            updateDoc,
             serverTimestamp
         } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 
@@ -391,6 +393,7 @@ CASINO</span>
 
         const STORAGE_USER_KEY = 'neonCasinoUser';
         const STORAGE_BALANCE_KEY = 'neonCasinoBalance';
+        const ADMIN_EMAIL = 'jhuxf12@outlook.com';
 
         const tabButtons = document.querySelectorAll('[data-auth-tab]');
         const forms = document.querySelectorAll('[data-form]');
@@ -553,7 +556,7 @@ CASINO</span>
             setFormLoading(loginForm, true);
             try {
                 const { user } = await signInWithEmailAndPassword(auth, email, password);
-                await setDoc(doc(db, 'users', user.uid), { lastLoginAt: serverTimestamp() }, { merge: true });
+                await setDoc(doc(db, 'users', user.uid), { lastLoginAt: serverTimestamp(), updatedAt: serverTimestamp() }, { merge: true });
                 showAlert('Signed in successfully!', 'success');
             } catch (error) {
                 console.error(error);
@@ -587,12 +590,27 @@ CASINO</span>
                 if (displayName) {
                     await updateProfile(user, { displayName });
                 }
+                const isAdminAccount = (email || '').toLowerCase() === ADMIN_EMAIL.toLowerCase();
                 await setDoc(doc(db, 'users', user.uid), {
                     displayName: displayName || null,
                     email,
                     balance: 100,
                     createdAt: serverTimestamp(),
-                    lastLoginAt: serverTimestamp()
+                    lastLoginAt: serverTimestamp(),
+                    updatedAt: serverTimestamp(),
+                    role: isAdminAccount ? 'Administrator' : 'Player',
+                    status: 'Active',
+                    vipTier: isAdminAccount ? 'Executive' : 'Bronze',
+                    riskLevel: 'Low',
+                    lifetimeDeposits: 0,
+                    lifetimeWagered: 0,
+                    lifetimePayouts: 0,
+                    segments: isAdminAccount ? ['Admin'] : [],
+                    notes: '',
+                    twoFactor: false,
+                    emailVerified: false,
+                    payoutHold: false,
+                    isAdmin: isAdminAccount
                 });
                 showAlert('Account created! $100 has been added to your wallet.', 'success');
             } catch (error) {
@@ -626,24 +644,133 @@ CASINO</span>
                 try {
                     const userRef = doc(db, 'users', user.uid);
                     const snapshot = await getDoc(userRef);
+                    const emailLower = (user.email || '').toLowerCase();
+                    const isAdminAccount = emailLower === ADMIN_EMAIL.toLowerCase();
+                    let profileData = snapshot.exists() ? snapshot.data() || {} : {};
                     let balance = 100;
 
-                    if (snapshot.exists()) {
-                        const data = snapshot.data();
-                        if (typeof data.balance === 'number') {
-                            balance = data.balance;
-                        }
-                    } else {
-                        await setDoc(userRef, {
+                    if (!snapshot.exists()) {
+                        const initialProfile = {
                             displayName: user.displayName ?? null,
                             email: user.email ?? null,
                             balance,
                             createdAt: serverTimestamp(),
-                            lastLoginAt: serverTimestamp()
-                        });
+                            lastLoginAt: serverTimestamp(),
+                            updatedAt: serverTimestamp(),
+                            role: isAdminAccount ? 'Administrator' : 'Player',
+                            status: 'Active',
+                            vipTier: isAdminAccount ? 'Executive' : 'Bronze',
+                            riskLevel: 'Low',
+                            lifetimeDeposits: 0,
+                            lifetimeWagered: 0,
+                            lifetimePayouts: 0,
+                            segments: isAdminAccount ? ['Admin'] : [],
+                            notes: '',
+                            twoFactor: false,
+                            emailVerified: user.emailVerified ?? false,
+                            payoutHold: false,
+                            isAdmin: isAdminAccount
+                        };
+                        await setDoc(userRef, initialProfile);
+                        profileData = initialProfile;
+                    } else {
+                        if (typeof profileData.balance === 'number') {
+                            balance = profileData.balance;
+                        }
+                        const updates = {};
+                        if (!profileData.displayName && user.displayName) {
+                            updates.displayName = user.displayName;
+                        }
+                        if (!profileData.status) {
+                            updates.status = 'Active';
+                        }
+                        if (!profileData.vipTier) {
+                            updates.vipTier = isAdminAccount ? 'Executive' : 'Bronze';
+                        }
+                        if (!profileData.riskLevel) {
+                            updates.riskLevel = 'Low';
+                        }
+                        if (!Array.isArray(profileData.segments)) {
+                            updates.segments = isAdminAccount ? ['Admin'] : [];
+                        }
+                        if (typeof profileData.lifetimeDeposits !== 'number') {
+                            updates.lifetimeDeposits = 0;
+                        }
+                        if (typeof profileData.lifetimeWagered !== 'number') {
+                            updates.lifetimeWagered = 0;
+                        }
+                        if (typeof profileData.lifetimePayouts !== 'number') {
+                            updates.lifetimePayouts = 0;
+                        }
+                        if (typeof profileData.emailVerified !== 'boolean') {
+                            updates.emailVerified = user.emailVerified ?? false;
+                        }
+                        if (typeof profileData.payoutHold !== 'boolean') {
+                            updates.payoutHold = false;
+                        }
+                        if (!profileData.role) {
+                            updates.role = isAdminAccount ? 'Administrator' : 'Player';
+                        }
+                        if (isAdminAccount) {
+                            const normalizedRole = (profileData.role || '').toLowerCase();
+                            if (normalizedRole !== 'administrator') {
+                                updates.role = 'Administrator';
+                            }
+                            if (profileData.vipTier !== 'Executive') {
+                                updates.vipTier = 'Executive';
+                            }
+                            if (profileData.isAdmin !== true) {
+                                updates.isAdmin = true;
+                            }
+                            const segmentSource = Object.prototype.hasOwnProperty.call(updates, 'segments')
+                                ? updates.segments
+                                : profileData.segments;
+                            const currentSegments = Array.isArray(segmentSource) ? segmentSource : [];
+                            if (!currentSegments.includes('Admin')) {
+                                updates.segments = Array.from(new Set([...currentSegments, 'Admin']));
+                            }
+                        }
+                        if (Object.keys(updates).length) {
+                            updates.updatedAt = serverTimestamp();
+                            await updateDoc(userRef, updates);
+                            profileData = { ...profileData, ...updates };
+                        }
                     }
 
-                    await setDoc(userRef, { lastLoginAt: serverTimestamp() }, { merge: true });
+                    balance = typeof profileData.balance === 'number' ? profileData.balance : balance;
+                    await updateDoc(userRef, {
+                        lastLoginAt: serverTimestamp(),
+                        updatedAt: serverTimestamp(),
+                        email: user.email ?? profileData.email ?? null
+                    });
+
+                    if (isAdminAccount) {
+                        const hasAdminRole = (profileData.role || '').toLowerCase() === 'administrator';
+                        const segments = Array.isArray(profileData.segments) ? profileData.segments : [];
+                        const ensuredSegments = Array.from(new Set([...segments, 'Admin']));
+                        const needsAdminPatch =
+                            profileData.isAdmin !== true ||
+                            !hasAdminRole ||
+                            profileData.vipTier !== 'Executive' ||
+                            ensuredSegments.length !== segments.length;
+
+                        if (needsAdminPatch) {
+                            await updateDoc(userRef, {
+                                isAdmin: true,
+                                role: 'Administrator',
+                                vipTier: 'Executive',
+                                segments: ensuredSegments,
+                                updatedAt: serverTimestamp()
+                            });
+                            profileData = {
+                                ...profileData,
+                                isAdmin: true,
+                                role: 'Administrator',
+                                vipTier: 'Executive',
+                                segments: ensuredSegments
+                            };
+                        }
+                    }
                     updateUserPanel(user, balance);
                     toggleForms(false);
                     persistSession(user, balance);

--- a/games.html
+++ b/games.html
@@ -783,10 +783,11 @@ CASINO</span>
                 <!-- Desktop Nav Links -->
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-white hover:text-primary transition">Home</a>
-                    <a href="#" class="text-primary transition" aria-current="page">Games</a>
-                    <a href="#" class="text-white hover:text-primary transition">Promotions</a>
-                    <a href="#" class="text-white hover:text-primary transition">Provably Fair</a>
-                  <a href="#" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="games.html" class="text-primary transition" aria-current="page">Games</a>
+                    <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+                    <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+                    <a href="#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
                 </div>
 
                 <!-- Wallet & Auth -->
@@ -812,10 +813,11 @@ CASINO</span>
             <div id="mobile-menu" class="md:hidden hidden flex-col space-y-4 pt-4 border-t border-gray-800" data-mobile-menu>
                 <div class="flex flex-col space-y-3">
                     <a href="index.html" class="text-white hover:text-primary transition">Home</a>
-                    <a href="#" class="text-primary transition font-semibold" aria-current="page">Games</a>
-                    <a href="#" class="text-white hover:text-primary transition">Promotions</a>
-                    <a href="#" class="text-white hover:text-primary transition">Provably Fair</a>
-                    <a href="#" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="games.html" class="text-primary transition font-semibold" aria-current="page">Games</a>
+                    <a href="index.html#promotions" class="text-white hover:text-primary transition">Promotions</a>
+                    <a href="index.html#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
+                    <a href="#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+                    <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
                 </div>
                 <div class="space-y-3 border-t border-gray-800 pt-4">
                     <div class="space-y-2">
@@ -1228,6 +1230,7 @@ CASINO</span>
         initNavigation();
 
         const DEFAULT_BALANCE = 1000;
+        const ADMIN_EMAIL = 'jhuxf12@outlook.com';
         const currencyFormatter = new Intl.NumberFormat('en-US', {
             minimumFractionDigits: 2,
             maximumFractionDigits: 2
@@ -1553,19 +1556,38 @@ CASINO</span>
             async function ensureProfile(user, options = {}) {
                 const userDocRef = doc(db, 'users', user.uid);
                 const snapshot = await getDoc(userDocRef);
-                const desiredName = options.displayName || deriveDisplayName(user, snapshot.data() || {});
+                const existingData = snapshot.exists() ? snapshot.data() || {} : {};
+                const desiredName = options.displayName || deriveDisplayName(user, existingData);
+                const emailLower = (user.email || '').toLowerCase();
+                const isAdminAccount = emailLower === ADMIN_EMAIL.toLowerCase();
 
                 if (!snapshot.exists()) {
-                    await setDoc(userDocRef, {
+                    const initialProfile = {
                         balance: defaultBalance,
                         displayName: desiredName,
                         email: user.email ?? null,
-                        updatedAt: serverTimestamp()
-                    });
-                    return { balance: defaultBalance, displayName: desiredName };
+                        createdAt: serverTimestamp(),
+                        lastLoginAt: serverTimestamp(),
+                        updatedAt: serverTimestamp(),
+                        role: isAdminAccount ? 'Administrator' : 'Player',
+                        status: 'Active',
+                        vipTier: isAdminAccount ? 'Executive' : 'Bronze',
+                        riskLevel: 'Low',
+                        lifetimeDeposits: 0,
+                        lifetimeWagered: 0,
+                        lifetimePayouts: 0,
+                        segments: isAdminAccount ? ['Admin'] : [],
+                        notes: '',
+                        twoFactor: false,
+                        emailVerified: user.emailVerified ?? false,
+                        payoutHold: false,
+                        isAdmin: isAdminAccount
+                    };
+                    await setDoc(userDocRef, initialProfile);
+                    return { ...initialProfile };
                 }
 
-                const data = snapshot.data() || {};
+                const data = { ...existingData };
                 const updates = {};
                 if (typeof data.balance !== 'number') {
                     updates.balance = defaultBalance;
@@ -1573,10 +1595,70 @@ CASINO</span>
                 if (!data.displayName && desiredName) {
                     updates.displayName = desiredName;
                 }
+                if (!data.status) {
+                    updates.status = 'Active';
+                }
+                if (!data.vipTier) {
+                    updates.vipTier = isAdminAccount ? 'Executive' : 'Bronze';
+                }
+                if (!data.riskLevel) {
+                    updates.riskLevel = 'Low';
+                }
+                if (!Array.isArray(data.segments)) {
+                    updates.segments = isAdminAccount ? ['Admin'] : [];
+                }
+                if (typeof data.lifetimeDeposits !== 'number') {
+                    updates.lifetimeDeposits = 0;
+                }
+                if (typeof data.lifetimeWagered !== 'number') {
+                    updates.lifetimeWagered = 0;
+                }
+                if (typeof data.lifetimePayouts !== 'number') {
+                    updates.lifetimePayouts = 0;
+                }
+                if (typeof data.emailVerified !== 'boolean') {
+                    updates.emailVerified = user.emailVerified ?? false;
+                }
+                if (typeof data.payoutHold !== 'boolean') {
+                    updates.payoutHold = false;
+                }
+                if (!data.role) {
+                    updates.role = isAdminAccount ? 'Administrator' : 'Player';
+                }
+                if (isAdminAccount) {
+                    const normalizedRole = (data.role || '').toLowerCase();
+                    if (normalizedRole !== 'administrator') {
+                        updates.role = 'Administrator';
+                    }
+                    if (data.vipTier !== 'Executive') {
+                        updates.vipTier = 'Executive';
+                    }
+                    if (data.isAdmin !== true) {
+                        updates.isAdmin = true;
+                    }
+                    const segmentSource = Object.prototype.hasOwnProperty.call(updates, 'segments')
+                        ? updates.segments
+                        : data.segments;
+                    const currentSegments = Array.isArray(segmentSource) ? segmentSource : [];
+                    if (!currentSegments.includes('Admin')) {
+                        updates.segments = Array.from(new Set([...currentSegments, 'Admin']));
+                    }
+                }
+                if (!data.createdAt) {
+                    updates.createdAt = serverTimestamp();
+                }
+                if (!data.lastLoginAt) {
+                    updates.lastLoginAt = serverTimestamp();
+                }
                 if (Object.keys(updates).length) {
                     updates.updatedAt = serverTimestamp();
                     await updateDoc(userDocRef, updates);
                 }
+                await updateDoc(userDocRef, {
+                    lastLoginAt: serverTimestamp(),
+                    updatedAt: serverTimestamp(),
+                    email: user.email ?? data.email ?? null
+                });
                 return { ...data, ...updates };
             }
 

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
           <a href="#promotions" class="text-white hover:text-primary transition">Promotions</a>
           <a href="#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
           <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+          <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
         </div>
 
         <!-- Wallet & Auth -->
@@ -107,6 +108,7 @@
           <a href="#promotions" class="text-white hover:text-primary transition">Promotions</a>
           <a href="#provably-fair" class="text-white hover:text-primary transition">Provably Fair</a>
           <a href="games.html#recent-games" class="text-white hover:text-primary transition">Leaderboard</a>
+          <a href="admin.html" class="text-white hover:text-primary transition">Admin</a>
         </div>
         <div class="space-y-3 border-t border-gray-800 pt-4">
           <div class="space-y-2">


### PR DESCRIPTION
## Summary
- wrap admin profile hydration in defensive reads and updates so permission issues no longer break verification
- treat the configured admin email as authoritative even if Firestore metadata is stale and keep local fallbacks aligned

## Testing
- node --check admin.js

------
https://chatgpt.com/codex/tasks/task_e_68ca189d76548320b08dd05a3afd5877